### PR TITLE
Summary: simple plugin which got out of hand.

### DIFF
--- a/summary/README.md
+++ b/summary/README.md
@@ -22,7 +22,7 @@ num_utxos=5
 utxo_amount=1.20119332000btc (USD $4473.84)
 num_channels=29
 num_connected=2
-num_gossipers=29
+num_gossipers=1
 avail_out=0.27095103btc (USD $1009.16)
 avail_in=2.05851379btc (USD $7666.93)
 channels_key=P=private O=offline

--- a/summary/README.md
+++ b/summary/README.md
@@ -1,0 +1,26 @@
+# Summary plugin
+
+This plugin is a little hack to show a summary of your node, including
+fiat amounts.
+
+## Options:
+
+* --summary-currency: Currency ticker to look up on bitaverage (default: `USD`)
+* --summary-currency-prefix: Prefix when printing currency (default: `USD $`)
+
+## Example Usage
+
+```
+$ lightning-cli summary | json_pp
+{
+   "network" : "TESTNET",
+   "utxo_amount" : "1.20119332000btc = USD $4582.22",
+   "avail_in" : "2.06940379btc = USD $7894.20",
+   "avail_out" : "0.27095103btc = USD $1033.60",
+   "my_address" : "031a3478d481b92e3c28810228252898c5f0d82fc4d07f5210c4f34d4aba56b769@165.227.30.200",
+   "num_channels" : 31,
+   "num_utxos" : 5,
+   "num_connected" : 1,
+   "num_gossipers" : 32
+}
+```

--- a/summary/README.md
+++ b/summary/README.md
@@ -1,7 +1,8 @@
 # Summary plugin
 
 This plugin is a little hack to show a summary of your node, including
-fiat amounts.
+fiat amounts.  If you have pylightning 0.0.7.1 or above, you get nice linegraphs,
+otherwise normal ASCII.
 
 ## Options:
 
@@ -18,41 +19,38 @@ $ lightning-cli summary | tr ',' '\n'
 {"network": "TESTNET"
  "my_address": "031a3478d481b92e3c28810228252898c5f0d82fc4d07f5210c4f34d4aba56b769@165.227.30.200"
  "num_utxos": 5
- "utxo_amount": "1.20119332000btc = USD $4589.24"
- "num_channels": 31
- "num_connected": 1
- "num_gossipers": 32
- "avail_out": "0.27095103btc = USD $1035.19"
- "avail_in": "2.06940379btc = USD $7906.30"
- "channels": ["         ---------------------------/          :02ac05912f89e43b88de3472e8c3003b"
- "          -------------------------/-          :02dd4cef0192611bc34cd1c3a0a7eb0f"
- "         /---------------------------          :02a13878947a133d7c96e70303a9bf27 (priv)"
- "                      /-                       :033e2db012833d997e3c"
- "                      /--                      :Kenny_Loggins"
- "/--------------------------------------------- :DeutscheTestnetBank"
- "/--------------------------------------------- :BlueLagoon1"
- "/--------------------------------------------- :0270dd38e8af9a64b4a483ab12b6aeb1"
- "                      /--                      :btctest.lnetwork.tokyo"
- "                    /-----                     :microbet.fun"
- "/--------------------------------------------- :02fcab6e34a2ad21be2a752ab96d13f5 (priv)"
- "/--------------------------------------------- :htlc.me"
- "                   /--------                   :02229ea9a7a4f9bf8bf25ce225079aed"
- "/--------------------------------------------- :025d5b572a94235cfcbdc429181b2b88"
- "          /-------------------------           :03c56de3a84336b4a939777ace9ecbef (priv)"
- "              /------------------              :LiteStrikeBTClnd"
- "      /----------------------------------      :037c9cf1cde4414c59407d547b7eac08 (priv)"
- "                       /                       :03490a74e4def9125a84aee2d84e8cfe"
- "  ---------------------/---------------------  :aranguren.org"
- "                       /                       :03cc6603e1f6df535dd8b423284f2c09 (priv)"
- "                      /-                       :cyclopes"
- "/--------------------------------------------- :02b73a2160863e925e9fa978b0ddc56b (priv)"
- "                   /--------                   :lnd-testnet.ignios.net"
- "                    /-----                     :0327a104108173d4a4f34ab2cbc3084c (priv)"
- "                     /----                     :dwarf"
- "                      /-                       :028133777757ce281658804dd82f5758 (priv)"
- "          /-------------------------           :02db62ffff5c35be74e7f856bba136db (priv)"
- "                       /                       :Lightning Tea"
- "                      /--                      :03015ac044f5fa9768ededf6fed9c0ff (priv)"
- "                      /--                      :LND-Neutrino-TEST"
- "/--------------------------------------------- :0270685ca81a8e4d4d01"]}
-```
+ "utxo_amount": "1.20119332000btc = USD $4476.10"
+ "num_channels": 29
+ "num_connected": 4
+ "num_gossipers": 27
+ "avail_out": "0.27095103btc = USD $1009.67"
+ "avail_in": "2.05851379btc = "
+ "channels": ["          ├────────────╢                       :02ac05912f89e43b88de3472e8c3003b"
+ "           ├───────────╢                       :02dd4cef0192611bc34cd1c3a0a7eb0f"
+ "                       ╟────────────┤          :02a13878947a133d7c96e70303a9bf27 (priv)"
+ "                       ║                       :033e2db012833d997e3c"
+ "                       ╟┤                      :Kenny_Loggins"
+ "                       ╟──────────────────────┤:DeutscheTestnetBank"
+ "                       ╟─────────────────────┤ :BlueLagoon1"
+ "                       ╟──────────────────────┤:0270dd38e8af9a64b4a483ab12b6aeb1"
+ "                       ╟┤                      :btctest.lnetwork.tokyo"
+ "                       ╟─┤                     :microbet.fun"
+ "                       ╟──────────────────────┤:02fcab6e34a2ad21be2a752ab96d13f5 (priv)"
+ "                       ╟──────────────────────┤:htlc.me"
+ "                       ╟───┤                   :02229ea9a7a4f9bf8bf25ce225079aed"
+ "                       ╟─────────────────────┤ :025d5b572a94235cfcbdc429181b2b88"
+ "                       ╟────────────┤          :03c56de3a84336b4a939777ace9ecbef (priv)"
+ "                       ╟────────┤              :LiteStrikeBTClnd"
+ "                       ╟────────────────┤      :037c9cf1cde4414c59407d547b7eac08 (priv)"
+ "                       ║                       :03490a74e4def9125a84aee2d84e8cfe"
+ "             ├─────────┼─────────┤             :aranguren.org"
+ "                       ║                       :03cc6603e1f6df535dd8b423284f2c09 (priv)"
+ "                       ║                       :cyclopes"
+ "                       ╟─────────────────────┤ :02b73a2160863e925e9fa978b0ddc56b (priv)"
+ "                       ╟───┤                   :lnd-testnet.ignios.net"
+ "                       ╟─┤                     :0327a104108173d4a4f34ab2cbc3084c (priv)"
+ "                       ╟─┤                     :dwarf"
+ "                       ║                       :028133777757ce281658804dd82f5758 (priv)"
+ "                       ╟────────────┤          :02db62ffff5c35be74e7f856bba136db (priv)"
+ "                       ╟┤                      :03015ac044f5fa9768ededf6fed9c0ff (priv)"
+ "                       ╟──────────────────────┤:0270685ca81a8e4d4d01"]}

--- a/summary/README.md
+++ b/summary/README.md
@@ -10,17 +10,49 @@ fiat amounts.
 
 ## Example Usage
 
+Unfortunately the python plugin framework doesn't pretty-print, nor does
+lightning-cli, and json_pp doesn't maintain order, so I use a hacky 'tr':
+
 ```
-$ lightning-cli summary | json_pp
-{
-   "network" : "TESTNET",
-   "utxo_amount" : "1.20119332000btc = USD $4582.22",
-   "avail_in" : "2.06940379btc = USD $7894.20",
-   "avail_out" : "0.27095103btc = USD $1033.60",
-   "my_address" : "031a3478d481b92e3c28810228252898c5f0d82fc4d07f5210c4f34d4aba56b769@165.227.30.200",
-   "num_channels" : 31,
-   "num_utxos" : 5,
-   "num_connected" : 1,
-   "num_gossipers" : 32
-}
+$ lightning-cli summary | tr ',' '\n'
+{"network": "TESTNET"
+ "my_address": "031a3478d481b92e3c28810228252898c5f0d82fc4d07f5210c4f34d4aba56b769@165.227.30.200"
+ "num_utxos": 5
+ "utxo_amount": "1.20119332000btc = USD $4589.24"
+ "num_channels": 31
+ "num_connected": 1
+ "num_gossipers": 32
+ "avail_out": "0.27095103btc = USD $1035.19"
+ "avail_in": "2.06940379btc = USD $7906.30"
+ "channels": ["         ---------------------------/          :02ac05912f89e43b88de3472e8c3003b"
+ "          -------------------------/-          :02dd4cef0192611bc34cd1c3a0a7eb0f"
+ "         /---------------------------          :02a13878947a133d7c96e70303a9bf27 (priv)"
+ "                      /-                       :033e2db012833d997e3c"
+ "                      /--                      :Kenny_Loggins"
+ "/--------------------------------------------- :DeutscheTestnetBank"
+ "/--------------------------------------------- :BlueLagoon1"
+ "/--------------------------------------------- :0270dd38e8af9a64b4a483ab12b6aeb1"
+ "                      /--                      :btctest.lnetwork.tokyo"
+ "                    /-----                     :microbet.fun"
+ "/--------------------------------------------- :02fcab6e34a2ad21be2a752ab96d13f5 (priv)"
+ "/--------------------------------------------- :htlc.me"
+ "                   /--------                   :02229ea9a7a4f9bf8bf25ce225079aed"
+ "/--------------------------------------------- :025d5b572a94235cfcbdc429181b2b88"
+ "          /-------------------------           :03c56de3a84336b4a939777ace9ecbef (priv)"
+ "              /------------------              :LiteStrikeBTClnd"
+ "      /----------------------------------      :037c9cf1cde4414c59407d547b7eac08 (priv)"
+ "                       /                       :03490a74e4def9125a84aee2d84e8cfe"
+ "  ---------------------/---------------------  :aranguren.org"
+ "                       /                       :03cc6603e1f6df535dd8b423284f2c09 (priv)"
+ "                      /-                       :cyclopes"
+ "/--------------------------------------------- :02b73a2160863e925e9fa978b0ddc56b (priv)"
+ "                   /--------                   :lnd-testnet.ignios.net"
+ "                    /-----                     :0327a104108173d4a4f34ab2cbc3084c (priv)"
+ "                     /----                     :dwarf"
+ "                      /-                       :028133777757ce281658804dd82f5758 (priv)"
+ "          /-------------------------           :02db62ffff5c35be74e7f856bba136db (priv)"
+ "                       /                       :Lightning Tea"
+ "                      /--                      :03015ac044f5fa9768ededf6fed9c0ff (priv)"
+ "                      /--                      :LND-Neutrino-TEST"
+ "/--------------------------------------------- :0270685ca81a8e4d4d01"]}
 ```

--- a/summary/README.md
+++ b/summary/README.md
@@ -12,45 +12,46 @@ otherwise normal ASCII.
 ## Example Usage
 
 Unfortunately the python plugin framework doesn't pretty-print, nor does
-lightning-cli, and json_pp doesn't maintain order, so I use a hacky 'tr':
+lightning-cli, so best viewed with -H:
 
 ```
-$ lightning-cli summary | tr ',' '\n'
-{"network": "TESTNET"
- "my_address": "031a3478d481b92e3c28810228252898c5f0d82fc4d07f5210c4f34d4aba56b769@165.227.30.200"
- "num_utxos": 5
- "utxo_amount": "1.20119332000btc = USD $4476.10"
- "num_channels": 29
- "num_connected": 4
- "num_gossipers": 27
- "avail_out": "0.27095103btc = USD $1009.67"
- "avail_in": "2.05851379btc = "
- "channels": ["          ├────────────╢                       :02ac05912f89e43b88de3472e8c3003b"
- "           ├───────────╢                       :02dd4cef0192611bc34cd1c3a0a7eb0f"
- "                       ╟────────────┤          :02a13878947a133d7c96e70303a9bf27 (priv)"
- "                       ║                       :033e2db012833d997e3c"
- "                       ╟┤                      :Kenny_Loggins"
- "                       ╟──────────────────────┤:DeutscheTestnetBank"
- "                       ╟─────────────────────┤ :BlueLagoon1"
- "                       ╟──────────────────────┤:0270dd38e8af9a64b4a483ab12b6aeb1"
- "                       ╟┤                      :btctest.lnetwork.tokyo"
- "                       ╟─┤                     :microbet.fun"
- "                       ╟──────────────────────┤:02fcab6e34a2ad21be2a752ab96d13f5 (priv)"
- "                       ╟──────────────────────┤:htlc.me"
- "                       ╟───┤                   :02229ea9a7a4f9bf8bf25ce225079aed"
- "                       ╟─────────────────────┤ :025d5b572a94235cfcbdc429181b2b88"
- "                       ╟────────────┤          :03c56de3a84336b4a939777ace9ecbef (priv)"
- "                       ╟────────┤              :LiteStrikeBTClnd"
- "                       ╟────────────────┤      :037c9cf1cde4414c59407d547b7eac08 (priv)"
- "                       ║                       :03490a74e4def9125a84aee2d84e8cfe"
- "             ├─────────┼─────────┤             :aranguren.org"
- "                       ║                       :03cc6603e1f6df535dd8b423284f2c09 (priv)"
- "                       ║                       :cyclopes"
- "                       ╟─────────────────────┤ :02b73a2160863e925e9fa978b0ddc56b (priv)"
- "                       ╟───┤                   :lnd-testnet.ignios.net"
- "                       ╟─┤                     :0327a104108173d4a4f34ab2cbc3084c (priv)"
- "                       ╟─┤                     :dwarf"
- "                       ║                       :028133777757ce281658804dd82f5758 (priv)"
- "                       ╟────────────┤          :02db62ffff5c35be74e7f856bba136db (priv)"
- "                       ╟┤                      :03015ac044f5fa9768ededf6fed9c0ff (priv)"
- "                       ╟──────────────────────┤:0270685ca81a8e4d4d01"]}
+$ lightning-cli -H summary
+network=TESTNET
+my_address=031a3478d481b92e3c28810228252898c5f0d82fc4d07f5210c4f34d4aba56b769@165.227.30.200
+num_utxos=5
+utxo_amount=1.20119332000btc (USD $4473.84)
+num_channels=29
+num_connected=2
+num_gossipers=29
+avail_out=0.27095103btc (USD $1009.16)
+avail_in=2.05851379btc (USD $7666.93)
+channels_key=P=private O=offline
+channels=          ├────────────╢                       (O):02ac05912f89e43b88de3472e8c3003b
+           ├───────────╢                       (O):02dd4cef0192611bc34cd1c3a0a7eb0f
+                       ╟────────────┤          (PO):02a13878947a133d7c96e70303a9bf27
+                       ║                       (O):033e2db012833d997e3c
+                       ╟┤                      (O):Kenny_Loggins
+                       ╟──────────────────────┤(O):DeutscheTestnetBank
+                       ╟─────────────────────┤ (O):BlueLagoon1
+                       ╟──────────────────────┤(O):0270dd38e8af9a64b4a483ab12b6aeb1
+                       ╟┤                      (O):btctest.lnetwork.tokyo
+                       ╟─┤                     (O):microbet.fun
+                       ╟──────────────────────┤(PO):02fcab6e34a2ad21be2a752ab96d13f5
+                       ╟──────────────────────┤(O):htlc.me
+                       ╟───┤                   (O):02229ea9a7a4f9bf8bf25ce225079aed
+                       ╟─────────────────────┤ (O):025d5b572a94235cfcbdc429181b2b88
+                       ╟────────────┤          (PO):03c56de3a84336b4a939777ace9ecbef
+                       ╟────────┤              (O):LiteStrikeBTClnd
+                       ╟────────────────┤      (PO):037c9cf1cde4414c59407d547b7eac08
+                       ║                       (O):03490a74e4def9125a84aee2d84e8cfe
+             ├─────────┼─────────┤             (O):aranguren.org
+                       ║                       (PO):03cc6603e1f6df535dd8b423284f2c09
+                       ║                       (O):cyclopes
+                       ╟─────────────────────┤ (PO):02b73a2160863e925e9fa978b0ddc56b
+                       ╟───┤                   (O):lnd-testnet.ignios.net
+                       ╟─┤                     (PO):0327a104108173d4a4f34ab2cbc3084c
+                       ╟─┤                     :dwarf
+                       ║                       (PO):028133777757ce281658804dd82f5758
+                       ╟────────────┤          (PO):02db62ffff5c35be74e7f856bba136db
+                       ╟┤                      (PO):03015ac044f5fa9768ededf6fed9c0ff
+                       ╟──────────────────────┤:0270685ca81a8e4d4d01

--- a/summary/requirements.txt
+++ b/summary/requirements.txt
@@ -1,2 +1,3 @@
 pylightning>=0.0.6
 requests>=2.0.0
+packaging>=14.1

--- a/summary/requirements.txt
+++ b/summary/requirements.txt
@@ -1,0 +1,2 @@
+pylightning>=0.0.6
+requests>=2.0.0

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -100,17 +100,18 @@ def summary(plugin):
                 to_them = Millisatoshi(0)
             avail_in += to_them
             reply['num_channels'] += 1
-            chans.append((c['total_msat'], to_us, to_them, p['id'], c['private']))
+            chans.append((c['total_msat'], to_us, to_them, p['id'], c['private'], p['connected']))
 
     reply['avail_out'] = avail_out.to_btc_str()
     reply['avail_in'] = avail_in.to_btc_str()
 
     if plugin.fiat_per_btc:
-        reply['utxo_amount'] += ' = {}'.format(to_fiatstr(utxo_amount))
-        reply['avail_out'] += ' = {}'.format(to_fiatstr(avail_out))
-        reply['avail_in'] += ' = '.format(to_fiatstr(avail_in))
+        reply['utxo_amount'] += ' ({})'.format(to_fiatstr(utxo_amount))
+        reply['avail_out'] += ' ({})'.format(to_fiatstr(avail_out))
+        reply['avail_in'] += ' ({})'.format(to_fiatstr(avail_in))
 
     if chans != []:
+        reply['channels_key'] = 'P=private O=offline'
         reply['channels'] = []
         biggest = max(max(int(c[1]), int(c[2])) for c in chans)
         for c in chans:
@@ -138,13 +139,20 @@ def summary(plugin):
                 right = "{:23}".format(draw.bar * (their_len - 1) + draw.right)
 
             s = left + mid + right
+
+            extra = ''
+            if c[4]:
+                extra += 'P'
+            if not c[5]:
+                extra += 'O'
+            if extra != '':
+                s += '({})'.format(extra)
+
             node = plugin.rpc.listnodes(c[3])['nodes']
             if len(node) != 0:
                 s += ':' + node[0]['alias']
             else:
                 s += ':' + c[3][0:32]
-            if c[4]:
-                s += ' (priv)'
             reply['channels'].append(s)
 
     return reply

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from lightning import Plugin, Millisatoshi
+import json
+import requests
+import threading
+import time
+
+plugin = Plugin(autopatch=True)
+
+
+class PriceThread(threading.Thread):
+    def run(self):
+        try:
+            r = requests.get('https://apiv2.bitcoinaverage.com/convert/global'
+                             '?from=BTC&to={}&amount=1'.format(plugin.currency))
+            plugin.fiat_per_btc = json.loads(r.content)['price']
+        except Exception:
+            pass
+        # Six hours is more than often enough for polling
+        time.sleep(6*3600)
+
+
+def to_fiatstr(msat: Millisatoshi):
+    return "{}{:.2f}".format(plugin.currency_prefix,
+                              int(msat) / 10**11 * plugin.fiat_per_btc)
+
+
+@plugin.method("summary")
+def summary(plugin):
+    """Gets summary information about this node."""
+
+    reply = {}
+    info = plugin.rpc.getinfo()
+    funds = plugin.rpc.listfunds()
+    peers = plugin.rpc.listpeers()
+
+    # Make it stand out if we're not on mainnet.
+    if info['network'] != 'bitcoin':
+        reply['network'] = info['network'].upper()
+
+    if not plugin.my_address:
+        reply['warning_no_address'] = "NO PUBLIC ADDRESSES"
+    else:
+        reply['my_address'] = plugin.my_address
+
+    utxo_amount = Millisatoshi(0)
+    reply['num_utxos'] = 0
+    for f in funds['outputs']:
+        if f['status'] != 'confirmed':
+            continue
+        utxo_amount += f['amount_msat']
+        reply['num_utxos'] += 1
+    reply['utxo_amount'] = utxo_amount.to_btc_str()
+
+    avail_out = Millisatoshi(0)
+    avail_in = Millisatoshi(0)
+    reply['num_channels'] = 0
+    reply['num_connected'] = 0
+    reply['num_gossipers'] = info['num_peers']
+    for p in peers['peers']:
+        for c in p['channels']:
+            if c['state'] != 'CHANNELD_NORMAL':
+                continue
+            if p['connected']:
+                reply['num_connected'] += 1
+                reply['num_gossipers'] -= 1
+            if c['our_reserve_msat'] < c['to_us_msat']:
+                avail_out += c['to_us_msat'] - c['our_reserve_msat']
+            # We have to derive amount to them
+            to_them_msat = c['total_msat'] - c['to_us_msat']
+            if c['their_reserve_msat'] < to_them_msat:
+                avail_in += to_them_msat - c['their_reserve_msat']
+            reply['num_channels'] += 1
+    reply['avail_out'] = avail_out.to_btc_str()
+    reply['avail_in'] = avail_in.to_btc_str()
+
+    if plugin.fiat_per_btc:
+        reply['utxo_amount'] += ' = ' + to_fiatstr(utxo_amount)
+        reply['avail_out'] += ' = ' + to_fiatstr(avail_out)
+        reply['avail_in'] += ' = ' + to_fiatstr(avail_in)
+
+    return reply
+
+
+@plugin.init()
+def init(options, configuration, plugin):
+    plugin.currency = options['summary-currency']
+    plugin.currency_prefix = options['summary-currency-prefix']
+    info = plugin.rpc.getinfo()
+
+    # Try to grab conversion price
+    PriceThread().start()
+
+    # Prefer IPv4, otherwise take any to give out address.
+    best_address = None
+    for a in info['address']:
+        if best_address is None:
+            best_address = a
+        elif a['type'] == 'ipv4' and best_address['type'] != 'ipv4':
+            best_address = a
+
+    if best_address:
+        plugin.my_address = info['id'] + '@' + best_address['address']
+        if best_address['port'] != 9735:
+            plugin.my_address += ':' + str(best_address['port'])
+
+    plugin.log("Plugin summary.py initialized")
+
+
+plugin.add_option(
+    'summary-currency',
+    'USD',
+    'What currency should I look up on btcaverage?'
+)
+plugin.add_option(
+    'summary-currency-prefix',
+    'USD $',
+    'What prefix to use for currency'
+)
+plugin.run()

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -78,14 +78,15 @@ def summary(plugin):
     chans = []
     reply['num_channels'] = 0
     reply['num_connected'] = 0
-    reply['num_gossipers'] = info['num_peers']
+    reply['num_gossipers'] = 0
     for p in peers['peers']:
+        active_channel = False
         for c in p['channels']:
             if c['state'] != 'CHANNELD_NORMAL':
                 continue
+            active_channel = True
             if p['connected']:
                 reply['num_connected'] += 1
-                reply['num_gossipers'] -= 1
             if c['our_reserve_msat'] < c['to_us_msat']:
                 to_us = c['to_us_msat'] - c['our_reserve_msat']
             else:
@@ -101,6 +102,9 @@ def summary(plugin):
             avail_in += to_them
             reply['num_channels'] += 1
             chans.append((c['total_msat'], to_us, to_them, p['id'], c['private'], p['connected']))
+
+        if not active_channel and p['connected']:
+            reply['num_gossipers'] += 1
 
     reply['avail_out'] = avail_out.to_btc_str()
     reply['avail_in'] = avail_in.to_btc_str()


### PR DESCRIPTION
We should add pretty-printing to lightning-cli (with an option to disable), and remove it from lightningd.  That would be faster, too, and avoid messy plugin output.