### PR TITLE
raw response fix

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -36,7 +36,7 @@ class PriceThread(threading.Thread):
         try:
             r = requests.get('https://apiv2.bitcoinaverage.com/convert/global'
                              '?from=BTC&to={}&amount=1'.format(plugin.currency))
-            plugin.fiat_per_btc = json.loads(r.content)['price']
+            plugin.fiat_per_btc = json.loads(r.content.decode())['price']
         except Exception:
             pass
         # Six hours is more than often enough for polling

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -36,7 +36,7 @@ class PriceThread(threading.Thread):
         try:
             r = requests.get('https://apiv2.bitcoinaverage.com/convert/global'
                              '?from=BTC&to={}&amount=1'.format(plugin.currency))
-            plugin.fiat_per_btc = json.loads(r.content.decode())['price']
+            plugin.fiat_per_btc = json.loads(r.content.decode('UTF-8'))['price']
         except Exception:
             pass
         # Six hours is more than often enough for polling


### PR DESCRIPTION
Not sure if this is a universal issue, price thread crashes while setting fiat_per_btc  as r.content is raw data. Running: packaging==19.0, requests==2.9.1 and pylightning==0.0.7.