### PR TITLE
Improve rebalance

### DIFF
--- a/rebalance/README.md
+++ b/rebalance/README.md
@@ -1,32 +1,52 @@
 # Rebalance plugin
 
-This plugin helps to move some msatoshis between your channels using circular payments.
+This plugin moves liquidity between your channels using circular payments.
 
-The plugin can be started with `lightningd` by adding the following `--plugin` option
-(adjusting the path to wherever the plugins are actually stored):
+The plugin can be started with `lightningd` by adding the following `--plugin`
+option. As with any `lightningd` plugin, the file has to be executable. As
+with any lightning python plugin, `pylightning` must be installed or in your
+`PYTHONPATH` environment variable.
 
 ```
 lightningd --plugin=/path/to/plugins/rebalance.py
 ```
 
 Once the plugin is active you can rebalance your channels liquidity by running:
-`lightning-cli rebalance outgoing_channel_id incoming_channel_id msatoshi [maxfeepercent] [retry_for] [exemptfee]`
 
-The `outgoing_channel_id` is the short_channel_id of the sending channel, `incoming_channel_id` is the id of the
-receiving channel. The `maxfeepercent` limits the money paid in fees and defaults to 0.5. The maxfeepercent' is a
-percentage of the amount that is to be paid. The `exemptfee` option can be used for tiny payments which would be
-dominated by the fee leveraged by forwarding nodes. Setting exemptfee allows the maxfeepercent check to be skipped
-on fees that are smaller than exemptfee (default: 5000 millisatoshi).
+```
+lightning-cli rebalance outgoing_scid incoming_scid [msatoshi] [maxfeepercent] [retry_for] [exemptfee]
+```
 
-The command will keep finding routes and retrying the payment until it succeeds, or the given `retry_for` seconds
-pass. retry_for defaults to 60 seconds and can only be an integer.
 
-### Tips and Tricks ###
-- The ideal amount is not too big, but not too small: it is difficult to find a route for a big payment, however
-some node refuses to forward too small amounts (i.e. less than a thousand msatoshi).
-- After some failed attempts, may worth checking the `lightningd` logs for further information.
-- Channels have a `channel_reserve_satoshis` value, which is usually 1% of the channel's total balance. Initially,
-this reserve may not be met, as only one side has funds; but the protocol ensures that there is always progress
-toward meeting this reserve, and once met, [it is
-maintained.](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#rationale)
-Therefore you cannot rebalance a channel to be completely empty or full.
+## Parameters
+
+ - The `outgoing_scid` is the short_channel_id of the sending channel,
+ - The `incoming_scid` is the short_channel_id of the receiving channel.
+ - OPTIONAL: The `msatoshi` parameter sets the amount in milli-satoshis to be
+   transferred. If the parameter is left out, the plugin will calucate an amount
+   that will balance the channels 50%/50%. The parameter can also be given in
+   other denominations by appending i.e. '10000sat' or '0.01btc'.
+ - OPTIONAL: `maxfeepercent` is a perecentage limit of the money to be paid in
+   fees and defaults to 0.5.
+ - OPTIONAL: `retry_for` defines the number of seconds the plugin will retry to
+   find a suitable route. Default: 60 seconds.
+ - OPTIONAL: The `exemptfee` option can be used for tiny payments which would be
+   dominated by the fee leveraged by forwarding nodes. Setting `exemptfee`
+   allows the `maxfeepercent` check to be skipped on fees that are smaller than
+   exemptfee (default: 5000 millisatoshi).
+
+
+## Tips and Tricks
+
+- To find the correct channel IDs, you can use the `summary` plugin which can
+  be found [here](https://github.com/lightningd/plugins/tree/master/summary).
+- The ideal amount is not too big, but not too small: it is difficult to find a
+  route for a big payment, however some node refuses to forward too small
+  amounts (i.e. less than a thousand msatoshi).
+- After some failed attempts, may worth checking the `lightningd` logs for
+  further information.
+- Channels have a `channel_reserve_satoshis` value, which is usually 1% of the
+  channel's total balance. Initially, this reserve may not be met, as only one
+  side has funds; but the protocol ensures that there is always progress toward
+  meeting this reserve, and once met, [it is maintained.](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#rationale)
+  Therefore you cannot rebalance a channel to be completely empty or full.

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -154,7 +154,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
             route = [route_out] + route_mid + [route_in]
             setup_routing_fees(plugin, route, msatoshi)
             fees = route[0]['msatoshi'] - route[-1]['msatoshi']
-            if fees > exemptfee and fees > msatoshi * float(maxfeepercent) / 100:
+            # NOTE: the int(msat) casts are just a workaround for outdated pylightning versions
+            if fees > exemptfee and int(fees) > int(msatoshi) * float(maxfeepercent) / 100:
                 worst_channel_id = find_worst_channel(route)
                 if worst_channel_id is None:
                     raise RpcError("rebalance", payload, {'message': 'Insufficient fee'})

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -20,12 +20,12 @@ def setup_routing_fees(plugin, route, msatoshi):
                 delay += ch['delay']
 
 
-def peer2channel(plugin, channel_id, my_node_id, payload):
-    channels = plugin.rpc.listchannels(channel_id).get('channels')
+def peer_from_scid(plugin, short_channel_id, my_node_id, payload):
+    channels = plugin.rpc.listchannels(short_channel_id).get('channels')
     for ch in channels:
         if ch['source'] == my_node_id:
             return ch['destination']
-    raise RpcError("rebalance", payload, {'message': 'Cannot find peer for channel: ' + channel_id})
+    raise RpcError("rebalance", payload, {'message': 'Cannot find peer for channel: ' + short_channel_id})
 
 
 def find_worst_channel(route):
@@ -71,8 +71,8 @@ def rebalance(plugin, outgoing_channel_id, incoming_channel_id, msatoshi: Millis
         "exemptfee": exemptfee
     }
     my_node_id = plugin.rpc.getinfo().get('id')
-    outgoing_node_id = peer2channel(plugin, outgoing_channel_id, my_node_id, payload)
-    incoming_node_id = peer2channel(plugin, incoming_channel_id, my_node_id, payload)
+    outgoing_node_id = peer_from_scid(plugin, outgoing_channel_id, my_node_id, payload)
+    incoming_node_id = peer_from_scid(plugin, incoming_channel_id, my_node_id, payload)
     plugin.log("Outgoing node: %s, channel: %s" % (outgoing_node_id, outgoing_channel_id))
     plugin.log("Incoming node: %s, channel: %s" % (incoming_node_id, incoming_channel_id))
 


### PR DESCRIPTION
I improved the UX of the rebalance plugin a bit:

- rebalance amount parameter will now optionally calculate for a 50% balancing if possible
- workaround a bug where outdated pylightning version will raise a exception (https://github.com/ElementsProject/lightning/pull/2601)
- some minor cleanups

Possible further TODOs:
- account for `their_reserve_msat` `our_reserve_msat` `spendable_msat` in `calc_optimal_amount`
- try sending several smaller payments if rebalance fails along the route
