### PR TITLE
sendinvoiceless list received payments

### DIFF
--- a/sendinvoiceless/README.md
+++ b/sendinvoiceless/README.md
@@ -1,29 +1,55 @@
 # Invoiceless payment plugin
 
-This plugin sends some msatoshis without needing to have an invoice from the receiving node. It uses circular
-payment: takes the money to the receiving node, pays in the form of routing fee, and brings some change back to
-close the circle.
+This plugin sends some msatoshis without needing to have an invoice from the
+receiving node. It uses circular payment: takes the money to the receiving node,
+pays in the form of routing fee, and brings some change back to close the circle.
 
-The plugin can be started with `lightningd` by adding the following `--plugin` option
-(adjusting the path to wherever the plugins are actually stored):
+The plugin can be started with `lightningd` by adding the following `--plugin`
+option (adjusting the path to wherever the plugins are actually stored):
 
 ```
 lightningd --plugin=/path/to/plugin/sendinvoiceless.py
 ```
 
+## Send money
 Once the plugin is active you can send payment by running:
-`lightning-cli sendinvoiceless nodeid msatoshi [maxfeepercent] [retry_for] [exemptfee]`
 
-The `nodeid` is the identifier of the receiving node. The `maxfeepercent` limits the money paid in fees and
-defaults to 0.5. The maxfeepercent' is a percentage of the amount that is to be paid. The `exemptfee` option can
-be used for tiny payments which would be dominated by the fee leveraged by forwarding nodes. Setting exemptfee
-allows the maxfeepercent check to be skipped on fees that are smaller than exemptfee (default: 5000 millisatoshi).
+```
+lightning-cli sendinvoiceless nodeid msatoshi [maxfeepercent] [retry_for] [exemptfee]
+```
 
-The command will keep finding routes and retrying the payment until it succeeds, or the given `retry_for` seconds
-pass. retry_for defaults to 60 seconds and can only be an integer.
+The `nodeid` is the identifier of the receiving node. The `maxfeepercent` limits
+the money paid in fees and defaults to 0.5. The `maxfeepercent` is a percentage
+of the amount that is to be paid. The `exemptfee` option can be used for tiny
+payments which would be dominated by the fee leveraged by forwarding nodes.
+Setting exemptfee allows the maxfeepercent check to be skipped on fees that are
+smaller than exemptfee (default: 5000 millisatoshi).
 
-## Known weaknesses
+The command will keep finding routes and retrying the payment until it succeeds,
+or the given `retry_for` seconds pass. retry_for defaults to 60 seconds and can
+only be an integer.
+
+### See also
+For a detailed explanation of the optional parameters, see also the manpage
+of the `pay` plugin: `lightning-pay(7)`
+
+## List payments
+If you want to check if you got paid by using this method, you can call this:
+
+```
+lightning-cli receivedinvoiceless [min_amount]
+```
+
+This will return an array of detected payments using this method. The plugin
+will filter the results by the optional `min_amount` parameter. Default: 10sat.
+The results will contain the `amount_msat` and `timestamp` of the payments.
+
+NOTE: The plugin currently does not use a database, so it can only assume fees
+have not changed in the past. It will also apply default fees for already
+forgotten channels. In both cases result can be slightly off by the changed fee.
+
+## Weaknesses
 This is kind of hack with some downsides:
-- The route is twice as long because of the circular payment. This may increase fees and failure probability.
+- The route is twice as long because of the circular payment. This will increase fees and failure probability.
 - The payee receives the money as a routing fee: hard to associate with anything, distinguish from the usual fees.
 - If the payment is going on a circular route A-B-C-D-A to pay C, and the same malicious entity controls B and D, the money can be stolen by skipping C.

--- a/sendinvoiceless/sendinvoiceless.py
+++ b/sendinvoiceless/sendinvoiceless.py
@@ -17,10 +17,7 @@ def setup_routing_fees(plugin, route, msatoshi, payload):
                 fee = Millisatoshi(ch['base_fee_millisatoshi'])
                 fee += msatoshi * ch['fee_per_millionth'] // 1000000
                 if ch['source'] == payload['nodeid']:
-                    if fee <= payload['msatoshi']:
-                        fee = payload['msatoshi']
-                    else:
-                        raise RpcError("sendinvoiceless", payload, {'message': 'Insufficient sending amount'})
+                    fee += payload['msatoshi']
                 msatoshi += fee
                 delay += ch['delay']
                 r['direction'] = int(ch['channel_flags']) % 2


### PR DESCRIPTION
This will add the command `receivedinvoiceless` which will
show the recent payments/donations being made to your node.

#### Usage
The plugin can be called like below. It will filter results by `min_amount` (default: `10sat`).
```
lightning-cli receivedinvoiceless [min_amount]
```

#### Returns
```
lightning-cli receivedinvoiceless 
[
   {
      "amount_msat" : "999600msat",
      "amount_btc" : "0.00001000btc",
      "resolved_time" : 1556558261.481,
      "timestamp" : "2019-04-29 17:17:41 (UTC)"
   }
]
```

#### Limitations
The plugin currently does not use a database, so it can only assume fees did not change in the past. else will produce slightly false results.