### PR TITLE
prometheus: Fix channel_id name and prevent crashing

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -104,7 +104,7 @@ class ChannelsCollector(BaseLnCollector):
         peers = self.rpc.listpeers()['peers']
         for p in peers:
             for c in p['channels']:
-                labels = [p['id'], c['short_channel_id']]
+                labels = [p['id'], c['channel_id']]
                 balance_gauge.add_metric(labels, c['to_us_msat'].to_satoshi())
                 spendable_gauge.add_metric(labels,
                                            c['spendable_msat'].to_satoshi())


### PR DESCRIPTION
With c-lightning v0.7.0, there seems to be no `short_channel_id`
key present in the input sent to the `prometheus.py` script when
it is is called via the `plugin` config value for c-lightning
when a channel is opened.

Without this change, the script throws `500 Internal Server` error
when doing `$ lightning-cli fundchannel <id> <sats>`.

A sample JSON messages passed to the plugin is:

```
{
        'state': 'CHANNELD_AWAITING_LOCKIN',
        'scratch_txid': '120ad265b66aa0c4bbb5ff50a23ca85463337fb8b58b395f3811918610686a734',
        'owner': 'lightning_channeld',
        'channel_id': 'eda784df73aa105d728a0d9fee6ff450eeeac78aa57d3218f7b0dd89b2bd20f1',
        'funding_txid': 'f120bdb2eec4b0f718327dc58cc7eaee5dd46fa19f0d8a725d10ff73df84a7ed',
        'private': False,
        'funding_allocation_msat': {
                '03584abd04d69168600ff0ff5d11723d324f2deadbeefcbb84804580e344af235e': 0,
                '03a9c46ddacd373f78b6679f9dec6adb10b3ddeadbeef2a685e09b2ce6101bc18c': 100000000
        },
        'funding_msat': {
                '03584abd04d69168600340ad5d11723d324f2deadbeefcbb84804580e344af235e': '0msat',
                '03a9c46ddacd373f78b6679f9dec6adb10b3ddeadbeef2a685e09b2ce6101bc18c': '100000000msat'
        },
        'msatoshi_to_us': 100000000,
        'to_us_msat': '100000000msat',
        'msatoshi_to_us_min': 100000000,
        'min_to_us_msat': '100000000msat',
        'msatoshi_to_us_max': 100000000,
        'max_to_us_msat': '100000000msat',
        'msatoshi_total': 100000000,
        'total_msat': '100000000msat',
        'dust_limit_satoshis': 546,
        'dust_limit_msat': '546000msat',
        'max_htlc_value_in_flight_msat': 18446744073709551615,
        'max_total_htlc_in_msat': '18446744073709551615msat',
        'their_channel_reserve_satoshis': 1000,
        'their_reserve_msat': 1000000msat,
        'our_channel_reserve_satoshis': 1000,
        'our_reserve_msat': '1000000msat',
        'spendable_msatoshi': 99000000,
        'spendable_msat': '99000000msat',
        'htlc_minimum_msat': 0,
        'minimum_htlc_in_msat': '0msat',
        'their_to_self_delay': 144,
        'our_to_self_delay': 144,
        'max_accepted_htlcs': 483,
        'status': ['CHANNELD_AWAITING_LOCKIN:Reconnected, and reestablished.', 'CHANNELD_AWAITING_LOCKIN:Funding needs more confirmations.'],
        'in_payments_offered': 0,
        'in_msatoshi_offered': 0,
        'in_offered_msat': '0msat',
        'in_payments_fulfilled': 0,
        'in_msatoshi_fulfilled': 0,
        'in_fulfilled_msat': '0msat',
        'out_payments_offered': 0,
        'out_msatoshi_offered': 0,
        'out_offered_msat': '0msat',
        'out_payments_fulfilled': 0,
        'out_msatoshi_fulfilled': 0,
        'out_fulfilled_msat': '0msat',
        'htlcs': []
}
```