### PR TITLE
fix: a race condition in the summary plugin

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -109,7 +109,7 @@ def summary(plugin):
     reply['avail_out'] = avail_out.to_btc_str()
     reply['avail_in'] = avail_in.to_btc_str()
 
-    if plugin.fiat_per_btc:
+    if plugin.fiat_per_btc > 0:
         reply['utxo_amount'] += ' ({})'.format(to_fiatstr(utxo_amount))
         reply['avail_out'] += ' ({})'.format(to_fiatstr(avail_out))
         reply['avail_in'] += ' ({})'.format(to_fiatstr(avail_in))
@@ -172,6 +172,7 @@ def summary(plugin):
 def init(options, configuration, plugin):
     plugin.currency = options['summary-currency']
     plugin.currency_prefix = options['summary-currency-prefix']
+    plugin.fiat_per_btc = 0
     info = plugin.rpc.getinfo()
 
     # Try to grab conversion price


### PR DESCRIPTION
When the summary plugin starts, it runs a thread to discover the current
`fiat_per_btc` price. When this was not finished yet, the `if` statement
in line 112 fails, because this in not JavaScript and the property has
to be checked with `hasattr(obj, key)` method in order to not throw an
exception.