### PR TITLE
Doc readme install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 Community curated plugins for c-lightning.
 
-To install and activate a plugin you need to stop your lightningd and restart it with the `plugin` argument like this:
-
-```
-lightningd --plugin=/path/to/plugin/directory/plugin_file_name.py
-```
-
-where the `plugin_file_name.py` should be an executable (`chmod a+x plugin_file_name.py`) file and can be written in any programming language.
 
 ## Available plugins
 
@@ -25,6 +18,54 @@ where the `plugin_file_name.py` should be an executable (`chmod a+x plugin_file_
 | [sendinvoiceless][sendinvoiceless] | Sends some money without an invoice from the receiving node.               |
 | [sitzprobe][sitzprobe]             | A Lightning Network payment rehearsal utility                              |
 | [summary][summary]                 | Print a nice summary of the node status                                    |
+
+
+## Installation
+
+To install and activate a plugin you need to stop your lightningd and restart it
+with the `plugin` argument like this:
+
+```
+lightningd --plugin=/path/to/plugin/directory/plugin_file_name.py
+```
+
+Notes:
+ - The `plugin_file_name.py` must have executable permissions:
+   `chmod a+x plugin_file_name.py`
+ - A plugin can be written in any programming language, as it interacts with
+   `lightningd` purely using stdin/stdout pipes.
+
+Alternatively, especially when you use multiple plugins, you can copy or symlink
+all plugins into your `lightningd` installation's `./plugins` directory.
+In this case `lightningd` will start all executables it finds in this directory
+as a plugin on startup. In this case you don't need to manage all the
+`--plugin=...` parameters. Note: The `pay` plugin also resides here.
+
+
+### Pylightning
+
+All python plugins depend on the `pylightning` library. It can be given in
+several ways:
+
+ - Using `pip` tools: `pip3 install pylightning`
+ - Using the `PYTHONPATH` environment variable to include your clightning's
+   shipped `pylightning` library:
+
+```bash
+PYTHONPATH=/path/to/lightnind/contrib/pylightning lightningd
+```
+
+### Additional dependencies
+
+Additionally, some Python plugins come with a `requirements.txt` which can be
+used to install the plugin's dependencies using the `pip` tools:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+Note: You might need to also specify the `--user` command line flag depending on
+your environment.
 
 
 ## More Plugins from the Community

--- a/rebalance/README.md
+++ b/rebalance/README.md
@@ -1,24 +1,24 @@
 # Rebalance plugin
 
-This plugin moves liquidity between your channels using circular payments.
+This plugin moves liquidity between your channels using circular payments:
 
-The plugin can be started with `lightningd` by adding the following `--plugin`
-option. As with any `lightningd` plugin, the file has to be executable. As
-with any lightning python plugin, `pylightning` must be installed or in your
-`PYTHONPATH` environment variable.
 
-```
-lightningd --plugin=/path/to/plugins/rebalance.py
-```
+## Installation
 
-Once the plugin is active you can rebalance your channels liquidity by running:
+For general plugin installation instructions see the repos main
+[README.md](https://github.com/lightningd/plugins/blob/master/README.md#Installation)
+
+
+## Usage
+
+Once the plugin is installed and active, you can use the `lightning-cli` to
+rebalance channels like this:
 
 ```
 lightning-cli rebalance outgoing_scid incoming_scid [msatoshi] [maxfeepercent] [retry_for] [exemptfee]
 ```
 
-
-## Parameters
+### Parameters
 
  - The `outgoing_scid` is the short_channel_id of the sending channel,
  - The `incoming_scid` is the short_channel_id of the receiving channel.

--- a/sendinvoiceless/README.md
+++ b/sendinvoiceless/README.md
@@ -4,14 +4,14 @@ This plugin sends some msatoshis without needing to have an invoice from the
 receiving node. It uses circular payment: takes the money to the receiving node,
 pays in the form of routing fee, and brings some change back to close the circle.
 
-The plugin can be started with `lightningd` by adding the following `--plugin`
-option (adjusting the path to wherever the plugins are actually stored):
 
-```
-lightningd --plugin=/path/to/plugin/sendinvoiceless.py
-```
+## Installation
 
-## Send money
+For general plugin installation instructions see the repos main
+[README.md](https://github.com/lightningd/plugins/blob/master/README.md#Installation)
+
+
+## Usage
 Once the plugin is active you can send payment by running:
 
 ```
@@ -33,6 +33,7 @@ only be an integer.
 For a detailed explanation of the optional parameters, see also the manpage
 of the `pay` plugin: `lightning-pay(7)`
 
+
 ## List payments
 If you want to check if you got paid by using this method, you can call this:
 
@@ -47,6 +48,7 @@ The results will contain the `amount_msat` and `timestamp` of the payments.
 NOTE: The plugin currently does not use a database, so it can only assume fees
 have not changed in the past. It will also apply default fees for already
 forgotten channels. In both cases result can be slightly off by the changed fee.
+
 
 ## Weaknesses
 This is kind of hack with some downsides:


### PR DESCRIPTION
This PR adds a unified and more complete plugin installation instruction guide in the main `README.md` so things must not be duplicated in the plugins subdirectories docs anymore. The plugins docs can simply reference to the main guide.