### PR TITLE
add lightningd blockheight metric

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -25,6 +25,13 @@ class NodeCollector(BaseLnCollector):
         node_info_fam.add_metric(info_labels, info_labels)
         yield node_info_fam
 
+        blockheight = info['blockheight']
+        yield GaugeMetricFamily(
+            'lightning_node_blockheight',
+            "Current Bitcoin blockheight on this node.",
+            value=blockheight,
+        )
+
 
 class FundsCollector(BaseLnCollector):
     def collect(self):


### PR DESCRIPTION
This metric is useful on initial sync, when bitcoind is already synced, but lightningd is still working through the blocks. Comparing the two measures allows to calculate the indexing progress.