### PR TITLE
rebalance: fix amount None

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -125,7 +125,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
 
     This tool helps to move some msatoshis between your channels.
     """
-    msatoshi = Millisatoshi(msatoshi)
+    if msatoshi:
+        msatoshi = Millisatoshi(msatoshi)
     maxfeepercent = float(maxfeepercent)
     retry_for = int(retry_for)
     exemptfee = Millisatoshi(exemptfee)


### PR DESCRIPTION
This was really stupid, before merging the last one, I added hard parameter casting at the top of the function without testing the amount `msatoshi` parameter for default (None) that was then used to call `Millisatoshi(None)`.