### PR TITLE
rebalance: fix route direction

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -157,8 +157,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
     if msatoshi > out_ours or msatoshi > in_total - in_ours:
         raise RpcError("rebalance", payload, {'message': 'Channel capacities too low'})
 
-    route_out = {'id': outgoing_node_id, 'channel': outgoing_scid}
-    route_in = {'id': my_node_id, 'channel': incoming_scid}
+    route_out = {'id': outgoing_node_id, 'channel': outgoing_scid, 'direction': int(not my_node_id < outgoing_node_id)}
+    route_in = {'id': my_node_id, 'channel': incoming_scid, 'direction': int(not incoming_node_id < my_node_id)}
     start_ts = int(time.time())
     label = "Rebalance-" + str(uuid.uuid4())
     description = "%s to %s" % (outgoing_scid, incoming_scid)


### PR DESCRIPTION
This will set the correct `direction` on manual route hops first and last (in/out).
Before this was not set, resulting in WIRE_FEE_INSUFFICIENT errors,
if fee was calculated (correctly) but inconsistently with `direction`, defaulting perhaps to `0`.

The error occurred on `sendpay` doing checks for the route I guess. I noticed this when having WIRE_FEE_INSUFFICIENT errors on last hop, where my peer had a higher fee setting than me and direction should have been 1.