### PR TITLE
Specify startup-only plugins to be non-dynamic

### DIFF
--- a/autopilot/autopilot.py
+++ b/autopilot/autopilot.py
@@ -109,7 +109,11 @@ class CLightning_autopilot(Autopilot):
                 print("Could not open a channel to {} with capacity of {}. Error: {}".format(nodeid, satoshis, str(e)))
 
 
-plugin = Plugin()
+try:
+    # C-lightning v0.7.2
+    plugin = Plugin(dynamic=False)
+except:
+    plugin = Plugin()
 
 
 @plugin.init()

--- a/autoreload/autoreload.py
+++ b/autoreload/autoreload.py
@@ -7,7 +7,11 @@ import threading
 import time
 import os
 
-plugin = Plugin()
+try:
+    # C-lightning v0.7.2
+    plugin = Plugin(dynamic=False)
+except:
+    plugin = Plugin()
 
 
 class ChildPlugin(object):


### PR DESCRIPTION
Cf [RPC plugins management](https://github.com/ElementsProject/lightning/pull/2771).

I tested all plugins from the repo and (aside from a little issue with socket absolute path in Pylightning), `autopilot` and `autoreload` were the only two requiring to be loaded at `lightningd` startup. Hence, I made in anticipation of the next release, the change to set the `dynamic` member to `False`.

I prefered a `try`...`except` over an additional dependency to check version numbers.