### PR TITLE
helpme: Wrap in `simple` format-hint, so lightning-cli prints it as -H

### DIFF
--- a/helpme/helpme.py
+++ b/helpme/helpme.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 from lightning import Plugin, Millisatoshi, RpcError
 from collections import defaultdict
+from functools import wraps
 from os import path
 import random
 import threading
@@ -896,7 +897,16 @@ Rusty Russell,
 Senior Code Monkey."""
 
 
+# Format hint `simple` makes lightning-cli print it as (-H) human readable
+def format_simple(fn):
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        return {'text': fn(*args, **kwargs), 'format-hint': 'simple'}
+    return wrapped
+
+
 @plugin.method("helpme")
+@format_simple
 def helpme(plugin, command=None, *args):
     """Gives helpful hints about running this node."""
 


### PR DESCRIPTION
A tiny fix to wrap `response` in `{'text': response, 'format-hint': 'simple'}`, so it looks better in lightning-cli.