### PR TITLE
rebalance: round HTLC fees up

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -15,7 +15,8 @@ def setup_routing_fees(plugin, route, msatoshi):
         channels = plugin.rpc.listchannels(r['channel'])
         ch = next(c for c in channels.get('channels') if c['destination'] == r['id'])
         fee = Millisatoshi(ch['base_fee_millisatoshi'])
-        fee += msatoshi * ch['fee_per_millionth'] // 10**6
+        # BOLT #7 requires fee >= fee_base_msat + ( amount_to_forward * fee_proportional_millionths / 1000000 )
+        fee += (msatoshi * ch['fee_per_millionth'] + 999_999) // 1_000_000	# integer math trick to round up
         msatoshi += fee
         delay += ch['delay']
 


### PR DESCRIPTION
[BOLT \#7](https://github.com/lightningnetwork/lightning-rfc/blob/v1.0/07-routing-gossip.md#htlc-fees) requires that nodes “SHOULD accept HTLCs that pay a fee equal to or greater than:  
`fee_base_msat + ( amount_to_forward * fee_proportional_millionths / 1000000 )`”.

The code in `rebalance.py:setup_routing_fees` was not strictly meeting the above requirement, as it was using truncating integer division to calculate the proportional part of the fee, which typically results in a fee that is strictly less than the theoretical, infinite-precision, required fee. Some node implementations may allow rounding down here, but some do not, resulting in sporadic `WIRE_FEE_INSUFFICIENT` errors.

This commit changes the fee calculation in `setup_routing_fees` so that it always rounds up to the next whole millisatoshi, thereby eliminating many `WIRE_FEE_INSUFFICIENT` errors and improving the success rate of the `rebalance` command.