### PR TITLE
fix: making sum() of funds iteration did not work on non-numeric

### DIFF
--- a/helpme/helpme.py
+++ b/helpme/helpme.py
@@ -451,7 +451,7 @@ node!  Be prepared to lose your funds (but please report a bug if you do!)
     if len(funds) == 0:
         r += "INCOMPLETE: No bitcoins yet.  Try 'helpme funds'"
     else:
-        funds = Millisatoshi(sum([funds['amount_msat'] for f in funds
+        funds = Millisatoshi(1000 * sum([f['value'] for f in funds
                                   if f['status'] == 'confirmed']))
         r += "COMPLETE ({} a.k.a {})".format(funds, funds.to_btc_str())
         stages['funds'] = True


### PR DESCRIPTION
Small fix:

Using `sum()` on Millisatoshi does not work and throws a TypeError.
We have to do the ugly `Millisatoshi(1000 * sum([value]))` way if we want to use `sum()`.

Note: also the plugin config detection does not seem to work as it should when using the default `~/.lightning/plugins` directory. The output from the **plugin** does not make sense in this context: 
```
...
STAGE 6 (adding bling): You have not added plugins.  Try 'helpme plugins'
```