### PR TITLE
sendinvoiceless: round HTLC fees up

### DIFF
--- a/sendinvoiceless/sendinvoiceless.py
+++ b/sendinvoiceless/sendinvoiceless.py
@@ -15,7 +15,8 @@ def setup_routing_fees(plugin, route, msatoshi, payload):
         channels = plugin.rpc.listchannels(r['channel'])
         ch = next(c for c in channels.get('channels') if c['destination'] == r['id'])
         fee = Millisatoshi(ch['base_fee_millisatoshi'])
-        fee += msatoshi * ch['fee_per_millionth'] // 10**6
+        # BOLT #7 requires fee >= fee_base_msat + ( amount_to_forward * fee_proportional_millionths / 1000000 )
+        fee += (msatoshi * ch['fee_per_millionth'] + 999_999) // 1_000_000     # integer math trick to round up
         if ch['source'] == payload['nodeid']:
             fee += payload['msatoshi']
         msatoshi += fee


### PR DESCRIPTION
This will apply the same fee rounding error correction as done to rebalance to the sendinvoiceless plugin:

```
477bdd8 rebalance: round HTLC fees up
```
