### PR TITLE
jitrebalance: First version of the JITrebalance plugin

### DIFF
--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -37,7 +37,8 @@ def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
         return
 
     # Check to see if the next channel has sufficient capacity
-    scid = onion['per_hop_v0']['short_channel_id']
+
+    scid = onion['short_channel_id'] if 'short_channel_id' in onion else '0x0x0'
 
     # Are we the destination? Then there's nothing to do. Continue.
     if scid == '0x0x0':
@@ -66,7 +67,7 @@ def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
     # account as well.
     #funder = chan['msatoshi_to_us_max'] == chan['msatoshi_total']
 
-    forward_amt = Millisatoshi(onion['per_hop_v0']['forward_amount'])
+    forward_amt = Millisatoshi(onion['forward_amount'])
     incoming_amt = Millisatoshi(htlc['amount'])
     fee = incoming_amt - forward_amt
     pprint(fee)

--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -104,7 +104,7 @@ def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
 
     # The HTLC might be a rebalance we ourselves initiated, better check
     # against the list of pending ones.
-    rebalance = plugin.rebalances.get(htlc['payment_hash'])
+    rebalance = plugin.rebalances.get(htlc['payment_hash'], None)
     if rebalance is not None:
         # Settle the rebalance, before settling the request that initiated the
         # rebalance.
@@ -118,6 +118,9 @@ def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
         time.sleep(1)
 
         rebalance['request'].set_result({"result": "continue"})
+
+        # Clean up our stash of active rebalancings.
+        del plugin.rebalances[htlc['payment_hash']]
         return
 
     # Check to see if the next channel has sufficient capacity

--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+from math import ceil
+from pprint import pprint
+from pyln.client import Plugin, Millisatoshi
+import binascii
+import hashlib
+import secrets
+import time
+
+plugin = Plugin()
+
+
+def get_circular_route(route, scid):
+    pass
+
+
+@plugin.async_hook("htlc_accepted")
+def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
+    plugin.log("Got an incoming HTLC htlc={}, onion={}".format(htlc, onion))
+
+    # The HTLC might be a rebalance we ourselves initiated, better check
+    # against the list of pending ones.
+    rebalance = plugin.rebalances.get(htlc['payment_hash'])
+    if rebalance is not None:
+        # Settle the rebalance, before settling the request that initiated the
+        # rebalance.
+        request.set_result({
+            "result": "resolve",
+            "payment_key": rebalance['payment_key']
+        })
+
+        # Now wait for it to settle correctly
+        # TODO Maybe be a bit smarter than having a fixed timeout here?
+        time.sleep(1)
+
+        rebalance['request'].set_result({"result": "continue"})
+        return
+
+    # Check to see if the next channel has sufficient capacity
+    scid = onion['per_hop_v0']['short_channel_id']
+
+    # Are we the destination? Then there's nothing to do. Continue.
+    if scid == '0x0x0':
+        request.set_result({"result": "continue"})
+        return
+
+    # Locate the channel + direction that would be the next in the path
+    peers = plugin.rpc.listpeers()['peers']
+
+    chan = None
+    peer = None
+    for p in peers:
+        for c in p['channels']:
+            if c['short_channel_id'] == scid:
+                chan = c
+                peer = p
+
+    # Check if the channel is active and routable, otherwise there's little
+    # point in even trying
+    if not peer['connected'] or chan['state'] != "CHANNELD_NORMAL":
+        request.set_result({"result": "continue"})
+        return
+
+    # Need to consider who the funder is, since they are paying the fees.
+    # TODO If we are the funder we need to take the cost of an HTLC into
+    # account as well.
+    #funder = chan['msatoshi_to_us_max'] == chan['msatoshi_total']
+
+    forward_amt = Millisatoshi(onion['per_hop_v0']['forward_amount'])
+    incoming_amt = Millisatoshi(htlc['amount'])
+    fee = incoming_amt - forward_amt
+    pprint(fee)
+    # Compute the amount we need to rebalance, give us a bit of breathing room
+    # while we're at it (25% more rebalancing than strictly necessary) so we
+    # don't end up with a completely unbalanced channel right away again, and
+    # to account for a bit of fuzziness when it comes to dipping into the
+    # reserve.
+    amt = ceil(int(forward_amt - chan['spendable_msat']) * 1.25)
+
+    # If we have a higher balance than is required we don't need to rebalance,
+    # just stop here.
+    if amt <= 0:
+        request.set_result({"result": "continue"})
+        return
+
+    # Compute the last leg of the route first, so we know the parameters to
+    # traverse that last edge.
+    reverse_chan = plugin.rpc.listchannels(scid)['channels']
+    assert(len(reverse_chan) == 2)
+    reverse_chan = [
+        c for c in reverse_chan if c['channel_flags'] != chan['direction']
+    ][0]
+
+    if reverse_chan is None:
+        print("Could not compute parameters for the last hop")
+        request.set_result({"result": "continue"})
+        return
+
+    last_amt = ceil(float(amt) +
+                    float(amt) * reverse_chan['fee_per_millionth'] / 10**6 +
+                    reverse_chan['base_fee_millisatoshi'])
+    last_cltv = 9 + reverse_chan['delay']
+
+    # Exclude the channel we are trying to rebalance when searching for a
+    # path. We will manually append it to the route and bump the other
+    # parameters so it can be used afterwards
+    exclusions = [
+        "{scid}/{direction}".format(scid=scid, direction=chan['direction'])
+    ]
+
+    route = plugin.rpc.getroute(
+        node_id=peer['id'],
+        msatoshi=last_amt,
+        riskfactor=1,
+        exclude=exclusions,
+        cltv=last_cltv,
+    )['route']
+
+    # Append the last hop we computed manually above
+    route += [{
+        'id': plugin.node_id,
+        'channel': scid,
+        'direction': chan['direction'],
+        'msatoshi': amt,
+        'amount_msat': '{}msat'.format(amt),
+        'delay': 9
+    }]
+
+    # We're about to initiate a rebalancing, we'd better remember how we can
+    # settle it once we see it back here.
+
+    payment_key = secrets.token_bytes(32)
+    payment_hash = hashlib.sha256(payment_key).hexdigest()
+    plugin.rebalances[payment_hash] = {
+        "payment_key": binascii.hexlify(payment_key).decode('ASCII'),
+        "payment_hash": payment_hash,
+        "request": request,
+    }
+
+    # After all this work we're finally in a position to judge whether a
+    # rebalancing is worth it at all. The rebalancing is considered worth it
+    # if the fees we're about to pay are less than or equal to the fees we get
+    # out of forwarding the payment.
+
+    plugin.log("Sending rebalance request using payment_hash={}".format(
+        payment_hash
+    ))
+    plugin.rpc.sendpay(route, payment_hash)
+
+
+@plugin.init()
+def init(options, configuration, plugin):
+    plugin.log("jitrebalance.py initializing {}".format(configuration))
+    plugin.node_id = plugin.rpc.getinfo()['id']
+
+    # Set of currently active rebalancings, keyed by their payment_hash
+    plugin.rebalances = {}
+
+
+plugin.run()

--- a/jitrebalance/requirements.txt
+++ b/jitrebalance/requirements.txt
@@ -1,0 +1,1 @@
+pyln-client==0.7.3

--- a/jitrebalance/test_jitrebalance.py
+++ b/jitrebalance/test_jitrebalance.py
@@ -1,0 +1,78 @@
+from pyln.testing.fixtures import *  # noqa: F401, F403
+from pyln.testing.utils import wait_for
+from pprint import pprint
+import os
+import time
+
+
+plugin = os.path.join(os.path.dirname(__file__), 'jitrebalance.py')
+
+
+def test_simple_rebalance(node_factory):
+    """Simple rebalance that routes along a cycle to enable the original payment
+
+    l1 ---- l2 ---- l3 ----- l4
+              |    /
+              |   /
+              |  /
+               l5
+
+    We are going to drain the channel (l2, l3) of most of its funds and then
+    ask l1 to route through [l1, l2, l3, l4]. Under normal circumstances
+    that'd fail since (l2, l3) doesn't have sufficient funds. l2 however will
+    attempt to rebalance (l2,l3) using a circular route (l2, l5, l3, l2) to
+    get the required funds back.
+
+    """
+    print(plugin)
+    opts = [{}, {'plugin': plugin}, {}, {}, {}]
+    l1, l2, l3, l4, l5 = node_factory.get_nodes(5, opts=opts)
+    amt = 10**7
+
+    # Open the channels
+    channels = [(l1, l2), (l3, l2), (l3, l4), (l2, l5), (l5, l3)]
+    for src, dst in channels:
+        src.openchannel(dst, capacity=10**6)
+
+    # Drain (l2, l3) so that a larger payment fails later on
+    chan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
+    pprint(chan)
+    # Send 9 million millisatoshis + reserve + a tiny fee allowance from l3 to
+    # l2 for the actual payment
+    inv = l2.rpc.invoice(
+        chan['our_channel_reserve_satoshis']*1000 + 9000000 + 100,
+        "imbalance", "imbalance"
+    )
+    time.sleep(1)
+    l3.rpc.pay(inv['bolt11'])
+
+    def no_pending_htlcs():
+        peer = l2.rpc.listpeers(l3.info['id'])['peers'][0]
+        return peer['channels'][0]['htlcs'] == []
+
+    wait_for(no_pending_htlcs)
+
+    chan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
+    pprint(chan)
+    assert(chan['spendable_msatoshi'] < amt)
+
+    # Get (l2, l5) so we can exclude it when routing from l1 to l4
+    peer = l2.rpc.listpeers(l5.info['id'])['peers'][0]
+    scid = peer['channels'][0]['short_channel_id']
+
+    # The actual invoice that l1 will attempt to pay to l4, and that will be
+    # larger than the current capacity of (l2, l3) so it triggers a
+    # rebalancing.
+    inv = l4.rpc.invoice(amt, "test", "test")
+
+    # Now wait for gossip to settle and l1 to learn the topology so it can
+    # then route the payment. We do this now since we already did what we
+    # could without this info
+    wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2*len(channels))
+
+    route = l1.rpc.getroute(node_id=l4.info['id'], msatoshi=amt, riskfactor=1,
+                            exclude=[scid + '/0', scid + '/1'])['route']
+
+    # This will fail without the plugin doing a rebalancing.
+    l1.rpc.sendpay(route, inv['payment_hash'])
+    pprint(l1.rpc.waitsendpay(inv['payment_hash']))

--- a/jitrebalance/test_jitrebalance.py
+++ b/jitrebalance/test_jitrebalance.py
@@ -1,6 +1,5 @@
 from pyln.testing.fixtures import *  # noqa: F401, F403
 from pyln.testing.utils import wait_for
-from pprint import pprint
 import os
 import time
 import unittest
@@ -38,7 +37,7 @@ def test_simple_rebalance(node_factory):
 
     # Drain (l2, l3) so that a larger payment fails later on
     chan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
-    pprint(chan)
+
     # Send 9 million millisatoshis + reserve + a tiny fee allowance from l3 to
     # l2 for the actual payment
     inv = l2.rpc.invoice(
@@ -55,7 +54,6 @@ def test_simple_rebalance(node_factory):
     wait_for(no_pending_htlcs)
 
     chan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
-    pprint(chan)
     assert(chan['spendable_msatoshi'] < amt)
 
     # Get (l2, l5) so we can exclude it when routing from l1 to l4
@@ -77,4 +75,4 @@ def test_simple_rebalance(node_factory):
 
     # This will fail without the plugin doing a rebalancing.
     l1.rpc.sendpay(route, inv['payment_hash'])
-    pprint(l1.rpc.waitsendpay(inv['payment_hash']))
+    l1.rpc.waitsendpay(inv['payment_hash'])

--- a/jitrebalance/test_jitrebalance.py
+++ b/jitrebalance/test_jitrebalance.py
@@ -3,11 +3,13 @@ from pyln.testing.utils import wait_for
 from pprint import pprint
 import os
 import time
+import unittest
 
 
 plugin = os.path.join(os.path.dirname(__file__), 'jitrebalance.py')
 
 
+@unittest.skipIf(not DEVELOPER, "gossip is too slow if we're not in developer mode")
 def test_simple_rebalance(node_factory):
     """Simple rebalance that routes along a cycle to enable the original payment
 


### PR DESCRIPTION
A simple implementation of a jit-rebalance plugin based in the idea of
@renepickhardt. Upon receiving an HTLC that we are supposed to forward check
whether the channel has sufficient capacity to forward. If that's not the case
we need to rebalance. For this we compute a circular route through some other
nodes, returning funds on the edge we are supposed to use when
forwarding. This means we rebalance the channel just enough to make forwarding
possible.

This only implements the simple version, without FOAF advertisements of free
rebalancings, but it already works rather nicely.

Suggested-by: Rene Pickhardt <@renepickhardt>
Signed-off-by: Christian Decker <@cdecker>