### PR TITLE
Fix networkx version

### DIFF
--- a/autopilot/requirements.txt
+++ b/autopilot/requirements.txt
@@ -1,4 +1,4 @@
 dnspython>=1.16.0
-networkx>=2.3
+networkx==2.3
 numpy>=1.16
 pylightning>=0.0.7


### PR DESCRIPTION
Graph.node has been renamed to Graph.nodes in version 2.4 at provokes a failure when running autopilot