### PR TITLE
A support plugin for lightningd's invoice and pay API call. 

### DIFF
--- a/balanced_amp_payments/README.md
+++ b/balanced_amp_payments/README.md
@@ -20,7 +20,7 @@ The plugin exposes no new command line options.
 
 The plugin also exposes the following methods:
 
- - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts respecing in a way that best decreases the imbalance of the nodes channels
+ - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts respecting in a way that best reduces the imbalance of the nodes channels.
 
  - `amp_pay_amounts`: splits an amount that is supposed to be send into smaller amounts respecing in a way that best decreases the imbalance of the nodes channels
 

--- a/balanced_amp_payments/README.md
+++ b/balanced_amp_payments/README.md
@@ -1,0 +1,33 @@
+# Balanced AMP Payments
+
+This plugin computes an optimal split of a payment amount for the use of AMP.
+The split is optimal in the sense that it reduces the imbalance of the funds of the node.
+
+More theory about imbalances and the algorithm to decrease the imblance of a node was
+suggested by this research by Rene Pickhardt and Mariusz Nowostawski: https://arxiv.org/abs/1912.09555
+
+This software is an adopted version as discussed in this post on the lightning-dev mailing
+list: https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-January/002418.html
+and was suggested to be created by ZmnSCPxj.
+
+> :warning: This plugin is still work in progress and may not work in all edge cases. :construction:
+
+## Command line options
+
+The plugin exposes no new command line options:
+   
+## JSON-RPC methods
+
+The plugin also exposes the following methods:
+
+ - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts respecing in a way that best decreases the imbalance of the nodes channels
+
+ - `amp_pay_amounts`: splits an amount that is supposed to be send into smaller amounts respecing in a way that best decreases the imbalance of the nodes channels
+
+Both API calls return a dictionary with short channel IDs and amounts
+   
+## Support: 
+If you like my work consider a donation at https://patreon.com/renepickhardt or https://tallyco.in/s/lnbook
+
+
+[lib]: https://github.com/ElementsProject/lightning/pull/1888

--- a/balanced_amp_payments/README.md
+++ b/balanced_amp_payments/README.md
@@ -19,9 +19,9 @@ The plugin exposes no new command line options.
 
 The plugin also exposes the following methods:
 
- - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts in a way that maximally reduces the imbalance of the nodes channels.
+ - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts in a way that maximally reduces the imbalance of the node's channels.
 
- - `amp_pay_amounts`: splits an amount that is supposed to be sent into smaller amounts respecting in a way that maximally decreases the imbalance of the nodes channels.
+ - `amp_pay_amounts`: splits an amount that is supposed to be sent into smaller amounts in a way that maximally decreases the imbalance of the node's channels.
 
 Both API calls return a dictionary with short channel IDs and amounts
    

--- a/balanced_amp_payments/README.md
+++ b/balanced_amp_payments/README.md
@@ -14,7 +14,7 @@ and was suggested to be created by ZmnSCPxj.
 
 ## Command line options
 
-The plugin exposes no new command line options:
+The plugin exposes no new command line options.
    
 ## JSON-RPC methods
 

--- a/balanced_amp_payments/README.md
+++ b/balanced_amp_payments/README.md
@@ -4,11 +4,10 @@ This plugin computes an optimal split of a payment amount for the use of AMP.
 The split is optimal in the sense that it reduces the imbalance of the funds of the node.
 
 More theory about imbalances and the algorithm to decrease the imblance of a node was
-suggested by this research by Rene Pickhardt and Mariusz Nowostawski: https://arxiv.org/abs/1912.09555
+suggested by [this research paper](https://arxiv.org/abs/1912.09555) by Rene Pickhardt and Mariusz Nowostawski: 
 
-This software is an adopted version as discussed in this post on the lightning-dev mailing
-list: https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-January/002418.html
-and was suggested to be created by ZmnSCPxj.
+This software is an adopted version as [discussed in this post on the lightning-dev](https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-January/002418.html) mailing
+lis and was suggested to be created by ZmnSCPxj.
 
 > :warning: This plugin is still work in progress and may not work in all edge cases. :construction:
 
@@ -20,9 +19,9 @@ The plugin exposes no new command line options.
 
 The plugin also exposes the following methods:
 
- - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts respecting in a way that best reduces the imbalance of the nodes channels.
+ - `amp_invoice_amounts`: splits an amount that is supposed to be received into smaller amounts in a way that maximally reduces the imbalance of the nodes channels.
 
- - `amp_pay_amounts`: splits an amount that is supposed to be send into smaller amounts respecing in a way that best decreases the imbalance of the nodes channels
+ - `amp_pay_amounts`: splits an amount that is supposed to be sent into smaller amounts respecting in a way that maximally decreases the imbalance of the nodes channels.
 
 Both API calls return a dictionary with short channel IDs and amounts
    

--- a/balanced_amp_payments/balanced_amp_payments.py
+++ b/balanced_amp_payments/balanced_amp_payments.py
@@ -32,7 +32,7 @@ If you like my work consider a donation at https://patreon.com/renepickhardt or 
 import json
 
 
-def helper_computer_node_parameters(channels):
+def helper_compute_node_parameters(channels):
     """
     computes the total funds (\tau) and the total capacity of a node (\kappa)
 
@@ -65,7 +65,7 @@ def recommend_incoming_channels(channels, amount):
     assert(amount <= total_receivable_amount), "can only receive %r but %r given" % (
         total_receivable_amount, amount)
 
-    kappa, tau = helper_computer_node_parameters(channels)
+    kappa, tau = helper_compute_node_parameters(channels)
     nu_target = float(tau + amount)/kappa
     channels = helper_compute_channel_balance_coefficients(channels)
 
@@ -106,7 +106,7 @@ def recommend_outgoing_channels(channels, amount, receiving=False):
     assert(amount <= total_sendable_amount), "can only send %r but %r given" % (
         total_sendable_amount, amount)
 
-    kappa, tau = helper_computer_node_parameters(channels)
+    kappa, tau = helper_compute_node_parameters(channels)
     nu_target = float(tau - amount)/kappa
     channels = helper_compute_channel_balance_coefficients(channels)
 

--- a/balanced_amp_payments/balanced_amp_payments.py
+++ b/balanced_amp_payments/balanced_amp_payments.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python3
+"""
+author: Rene Pickhardt (rene.m.pickhardt@ntnu.no)
+Date: 14.1.2020
+License: MIT
+
+This code computes an optimal split of a payment amount for the use of AMP.
+The split is optimal in the sense that it reduces the imbalance of the funds of the node.
+
+More theory about imbalances and the algorithm to decrease the imblance of a node was
+suggested by this research: https://arxiv.org/abs/1912.09555
+
+This software is an adopted version as discussed in this post on the lightning-dev mailing
+list: https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-January/002418.html
+
+It will also compute a split to receive funds over various channels with the same math
+theory.
+
+The intended use of this code is with the pay-plugin of lighting and for the invoice API
+call which ships together with this file. 
+
+See example.py for an example how this code can be run. 
+
+Also have a look at the plugin file
+
+=== Support: 
+If you like my work consider a donation at https://patreon.com/renepickhardt or https://tallyco.in/s/lnbook
+
+
+"""
+
+import json
+
+
+def helper_computer_node_parameters(channels):
+    """
+    computes the total funds (\tau) and the total capacity of a node (\kappa)
+
+    channels: is a list of local channels. Entries are formatted as in `listunfunds` API call
+
+    returns total capacity (\kappa) and total funds (\tau) of the node as integers in satoshis.
+    """
+    kappa = sum(x["channel_total_sat"] for x in channels)
+    tau = sum(x["channel_sat"] for x in channels)
+    return kappa, tau
+
+
+def helper_compute_channel_balance_coefficients(channels):
+    # assign zetas to channels:
+    for c in channels:
+        c["zeta"] = float(c["channel_sat"]) / c["channel_total_sat"]
+    return channels
+
+
+def recommend_incoming_channels(channels, amount):
+    assert(amount > 0), "cant receive negative amounts"
+
+    # we need to respect the channel reserve
+    total_receivable_amount = 0
+    for c in channels:
+        reserve = c["channel_total_sat"] / 100
+        receivable_amount = max(
+            0, c["channel_total_sat"] - c["channel_sat"] - reserve)
+        total_receivable_amount += receivable_amount
+    assert(amount <= total_receivable_amount), "can only receive %r but %r given" % (
+        total_receivable_amount, amount)
+
+    kappa, tau = helper_computer_node_parameters(channels)
+    nu_target = float(tau + amount)/kappa
+    channels = helper_compute_channel_balance_coefficients(channels)
+
+    # compute rebalance amounts for channels with channel balance coefficients lower than targeted node balance coefficient
+    total_rebalance_fractions = 0
+    rebalance_fractions = {}
+    for c in channels:
+        if c["zeta"] < nu_target:
+            rebalance_fraction = c["channel_total_sat"] * \
+                (nu_target - c["zeta"])
+            rebalance_fractions[c["short_channel_id"]] = rebalance_fraction
+            total_rebalance_fractions += rebalance_fraction
+
+    # round everything up.
+    return {k: int(v * amount / total_rebalance_fractions + 0.5)for k, v in rebalance_fractions.items()}, nu_target
+
+
+def recommend_outgoing_channels(channels, amount, receiving=False):
+    """
+    recommends how a pay amount should be split across local channels in a multipath payment scheme
+
+
+    channels: is a list of local channels. Entries are formatted as in `listfunds` API call
+    amount: is the amount that is supposed to be send
+
+    Returns a dictionary of channeles with short_channel_ids as keys and recommended amounts as values.
+
+    Since small overpayments are part of the protocol the amounts will be rounded up to the next satoshi instead of using millisatoshis
+    """
+    assert(amount > 0), "cant send negative amounts"
+
+    # we need to respect the channel reserve
+    total_sendable_amount = 0
+    for c in channels:
+        reserve = c["channel_total_sat"] / 100
+        sendable_amount = max(0, c["channel_sat"] - reserve)
+        total_sendable_amount += sendable_amount
+    assert(amount <= total_sendable_amount), "can only send %r but %r given" % (
+        total_sendable_amount, amount)
+
+    kappa, tau = helper_computer_node_parameters(channels)
+    nu_target = float(tau - amount)/kappa
+    channels = helper_compute_channel_balance_coefficients(channels)
+
+    # compute rebalance amounts for channels with channel balance coefficients higher than targeted node balance coefficient
+    total_rebalance_fractions = 0
+    rebalance_fractions = {}
+    for c in channels:
+        if c["zeta"] > nu_target:
+            rebalance_fraction = c["channel_total_sat"] * \
+                (nu_target - c["zeta"])
+            rebalance_fractions[c["short_channel_id"]] = rebalance_fraction
+            total_rebalance_fractions += rebalance_fraction
+
+    # round everything up. we are going to pay fees anyway. we could do msats but obfuscating is also nice
+    return {k: int(v * amount / total_rebalance_fractions + 0.5)for k, v in rebalance_fractions.items()}, nu_target

--- a/balanced_amp_payments/balanced_amp_payments_plugin.py
+++ b/balanced_amp_payments/balanced_amp_payments_plugin.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+"""
+author: Rene Pickhardt (rene.m.pickhardt@ntnu.no)
+Date: 14.1.2020
+License: MIT
+
+This plugin computes an optimal split of a payment amount for the use of AMP.
+The split is optimal in the sense that it reduces the imbalance of the funds of the node.
+
+More theory about imbalances and the algorithm to decrease the imblance of a node was
+suggested by this research: https://arxiv.org/abs/1912.09555
+
+This software is an adopted version as discussed in this post on the lightning-dev mailing
+list: https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-January/002418.html
+
+It will also compute a split to receive funds over various channels with the same math
+theory.
+
+The intended use of this code ist to support a pay-plugin and the invoice command if they use AMP
+
+A few improvements might be possible:
+- Decide if amount should be rounded up / down
+- filter the channels from listchannels to the ones that are currently online (check with listpeers)
+
+=== Support: 
+If you like my work consider a donation at https://patreon.com/renepickhardt or https://tallyco.in/s/lnbook
+"""
+
+from pyln.client import Plugin
+import lightning
+import balanced_amp_payments as bp
+
+plugin = Plugin(autopatch=True)
+
+amp_pay_amounts_description = "Suggests a balanced split of pay amounts to be used in AMP payments"
+@plugin.method("amp_pay_amounts", long_desc=amp_pay_amounts_description)
+def amp_pay_amounts(plugin, amount):
+    """
+    Suggests a balanced split of pay amounts to be used in AMP payments
+    """
+    channels = plugin.rpc.listfunds()["channels"]
+    return bp.recommend_outgoing_channels(channels, amount)[0]
+
+
+amp_invoice_amounts_description = "Suggests a balanced split of amounts to be used in AMP invoices"
+@plugin.method("amp_invoice_amounts", long_desc=amp_invoice_amounts_description)
+def amp_invoice_amounts(plugin, amount):
+    """
+    Suggests a balanced split of pay amounts to be used in AMP invoices
+    """
+    channels = plugin.rpc.listfunds()["channels"]
+    return bp.recommend_incoming_channels(channels, amount)[0]
+
+
+@plugin.init()
+def init(options, configuration, plugin):
+    #info = plugin.rpc.getinfo()
+    plugin.log("Plugin balanced_payments.py initialized")
+
+
+plugin.run()

--- a/balanced_amp_payments/example.py
+++ b/balanced_amp_payments/example.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+"""
+author: Rene Pickhardt (rene.m.pickhardt@ntnu.no)
+Date: 14.1.2020
+License: MIT
+
+some example code to demonstrate the functionality of the balanced pay code
+which is used in the balanced_amp_payments_plugin. 
+
+You will need a file called listfunds.json which should contain the output
+of your lightning node's listfunds command. you can get it by:
+
+lightning-cli listfunds > listfunds.json
+
+and then run the script from the same directory
+
+python3 example.py
+
+=== Support: 
+If you like my work consider a donation at https://patreon.com/renepickhardt or https://tallyco.in/s/lnbook
+"""
+
+import balanced_amp_payments as bp
+import json
+
+
+def helper_fn_parse_jsn(show_schema=False):
+    f = open("listfunds.json")
+    jsn = ""
+    for l in f:
+        if len(l) < 2:
+            continue
+        jsn = jsn + l
+    listfunds = json.loads(jsn)["channels"]
+    if show_schema:
+        for el in listfunds:
+            for k, v in el.items():
+                print(k, v)
+            break
+    return listfunds
+
+
+def display_results(channels, res, receiving=False):
+    untouched_channel_stats = ""
+    print("targeting for a balance coefficient of: {:4.2f}".format(nu))
+    for chan in channels:
+        sid = chan["short_channel_id"]
+        cap = chan["channel_total_sat"]
+        balance = chan["channel_sat"]
+        zeta_old = float(balance)/cap
+
+        if sid in res:
+            if receiving:
+                zeta_new = float(balance + res[sid])/cap
+            else:
+                zeta_new = float(balance - res[sid])/cap
+            print("{}\t{}\t{}\t{}\t{:5.3f}\t{:5.3f}".format(
+                sid, chan["channel_total_sat"], chan["channel_sat"], res[sid], zeta_old, zeta_new))
+        else:
+            untouched_channel_stats += "{}\t{}\t{}\t0\t{:5.3f}\t{:5.3f}\n".format(
+                sid, chan["channel_total_sat"], chan["channel_sat"], zeta_old, zeta_old)
+    if len(untouched_channel_stats) > 10:
+        print("---- untouched_channels ----")
+        print(untouched_channel_stats)
+
+
+channels = helper_fn_parse_jsn(False)
+res, nu = bp.recommend_outgoing_channels(channels, 14000000)
+display_results(channels, res, receiving=False)
+
+res, nu = bp.recommend_incoming_channels(channels, 60000000)
+display_results(channels, res, receiving=True)


### PR DESCRIPTION
If `lightningd` users want to make AMP payments `lightningd` could use this plugin to compute the optimal split off the amount that helps to rebalance it's own channels in the best way.

you can test the code by running `example.py` before you need to do `lightning-cli listfunds > listfunds.json` as described in `example.py`

Looking forward for your review and thoughts.

edit (for easier reference some background info):
More theory about imbalances and the algorithm to decrease the imblance of a node was
suggested by this research by Rene Pickhardt and Mariusz Nowostawski: https://arxiv.org/abs/1912.09555

This software is an adopted version as discussed in this post on the lightning-dev mailing
list: https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-January/002418.html
and was suggested to be created by ZmnSCPxj.