### PR TITLE
Add link to plugin collection emulating some of the LND (lncli) commands on c-lightning

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ your environment.
  - [@renepickhardt's plugins](https://github.com/renepickhardt/c-lightning-plugin-collection)
  - [@fiatjaf's plugins](https://github.com/fiatjaf/lightningd-gjson-rpc/tree/master/cmd)
  - [@rsbondi's plugins](https://github.com/rsbondi/clightning-go-plugin)
+ - [c-lightning plugins emulating commands of LND (lncli)](https://github.com/kristapsk/c-lightning-lnd-plugins)
 
 ## Plugin Builder Resources
 


### PR DESCRIPTION
I've written plugins for c-lightning implementing `lncli feereport` and `lncli walletbalance`. Decided to put them together in a single repo as a submodules. Idea is that other people doing similar stuff (implementing `lncli` stuff for c-lightning) could add their plugins there too in future.