### PR TITLE
Add coverage for python plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ before_install:
 script:
   .travis/build.sh
 
+after_success:
+  - coveralls

--- a/.travis/bin/python3
+++ b/.travis/bin/python3
@@ -1,0 +1,3 @@
+#!/bin/bash
+export COVERAGE_FILE=/tmp/.coverage
+coverage run --omit='/home/travis/.local/,*/.direnv/*' --parallel-mode "$@"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -26,7 +26,9 @@ pip3 install --user --quiet \
      mako==1.0.14 \
      psycopg2-binary==2.8.3 \
      pytest-timeout==1.3.3 \
-     pytest-xdist==1.30.0
+     pytest-xdist==1.30.0 \
+     coverage \
+     coveralls
 
 # Install the pyln-client and testing library matching c-lightning `master`
 
@@ -49,4 +51,14 @@ fi
 # Collect libraries that the plugins need and install them
 find . -name requirements.txt -exec pip3 install --user -r {} \;
 
+# Enable coverage reporting from inside the plugin. This is done by adding a
+# wrapper called python3 that internally just calls `coverage run` and stores
+# the coverage output in `/tmp/.coverage.*` from where we can pick the details
+# up again.
+PATH="$(pwd)/.travis/bin:$PATH"
+export PATH
+
 pytest -vvv --timeout=550 --timeout_method=thread -p no:logging -n 10
+
+# Now collect the results in a single file so coveralls finds them
+coverage combine /tmp/.coverage.*

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -27,7 +27,7 @@ pip3 install --upgrade pip
 pip3 install --user --quiet \
      pyln-testing \
      mako==1.0.14 \
-     psycopg2-binary==2.8.3 \
+     psycopg2-binary>=2.8.3 \
      pytest-timeout==1.3.3 \
      pytest-xdist==1.30.0 \
      coverage \

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -12,13 +12,16 @@ export PYTHONPATH=/tmp/lightning/contrib/pyln-client:/tmp/lightning/contrib/pyln
 mkdir -p dependencies/bin
 
 # Download bitcoind and bitcoin-cli 
+echo 'travis_fold:start:script.0'
 if [ ! -f dependencies/bin/bitcoind ]; then
     wget https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
     tar -xzf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
     mv bitcoin-0.17.1/bin/* dependencies/bin
     rm -rf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz bitcoin-0.17.1
 fi
+echo 'travis_fold:end:script.0'
 
+echo 'travis_fold:start:script.1'
 pyenv global 3.7
 pip3 install --upgrade pip
 pip3 install --user --quiet \
@@ -30,10 +33,13 @@ pip3 install --user --quiet \
      coverage \
      coveralls
 
+echo 'travis_fold:end:script.1'
+
 # Install the pyln-client and testing library matching c-lightning `master`
 
 PY3=$(which python3)
 
+echo 'travis_fold:start:script.2'
 git clone --recursive https://github.com/ElementsProject/lightning.git /tmp/lightning
 (cd /tmp/lightning && git checkout "$LIGHTNING_VERSION")
 (cd /tmp/lightning/contrib/pyln-client && $PY3 setup.py install)
@@ -47,9 +53,12 @@ if [ ! -f "$CWD/dependencies/usr/local/bin/lightningd" ]; then
 	make -j 8 DESTDIR=dependencies/
     )
 fi
+echo 'travis_fold:end:script.2'
 
 # Collect libraries that the plugins need and install them
+echo 'travis_fold:start:script.3'
 find . -name requirements.txt -exec pip3 install --user -r {} \;
+echo 'travis_fold:end:script.3'
 
 # Enable coverage reporting from inside the plugin. This is done by adding a
 # wrapper called python3 that internally just calls `coverage run` and stores

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Community curated plugins for c-lightning.
 
 [![Build Status](https://travis-ci.org/lightningd/plugins.svg?branch=master)](https://travis-ci.org/lightningd/plugins)
+[![Coverage Status](https://coveralls.io/repos/github/lightningd/plugins/badge.svg?branch=master)](https://coveralls.io/github/lightningd/plugins?branch=master)
 
 ## Available plugins
 


### PR DESCRIPTION
This PR adds the ability to run `coverage` inside a plugin, to check how well
the tests exercise the available functionality. The way we achieve this is by
providing a small wrapper around `python3` in `.travis/bin/` which is added to
the `$PATH` before the actual `python3` binary. The wrapper calls `coverage
run` instead of `python3` directly, and makes sure that the coverage results
are stashed in separate files in `/tmp/.coverage.*`. The results are then
combined into a single coverage file and `coveralls` is called to deliver the
coverage results to coveralls.io where we can track progress.

In order to use the wrapper we need to have the folloing shebang:

```bash
#!/usr/bin/env python3
```

This will make sure that the `python3` executable is picked from the `$PATH`
variable and thus that our wrapper is called instead of the interpreter
directly. This is a good idea anyway since it also supports virtualenvs
natively.