### PR TITLE
backup: Remove duplicate call of initialize()

### DIFF
--- a/backup/requirements.txt
+++ b/backup/requirements.txt
@@ -1,2 +1,3 @@
 Click==7.0
+flaky>=3.6.1
 tqdm>=4.45


### PR DESCRIPTION
Before this change, backup backend was initialized twice - in on_init()
and get_backend() functions. This change leaves only one call in
get_backend() and adds a kwarg determining whether init failure should
be fatal.

Signed-off-by: Michal Rostecki <mrostecki@mailfence.com>