### PR TITLE
Prometheus: avoid hyphens in label names

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -16,7 +16,7 @@ class BaseLnCollector(object):
 class NodeCollector(BaseLnCollector):
     def collect(self):
         info = self.rpc.getinfo()
-        info_labels = {k: v for k, v in info.items() if isinstance(v, str)}
+        info_labels = {k.replace('-', '_'): v for k, v in info.items() if isinstance(v, str)}
         node_info_fam = InfoMetricFamily(
             'lightning_node',
             'Static node information',


### PR DESCRIPTION
Prometheus 2.7.1+ds apparently doesn't accept hyphens in label names. Replacing them with underscores fixes the error I got otherwise:
```
error while linting: text format parsing error in line 3: expected '=' after label name, found '-'
```