### PR TITLE
helpme: fix out of range access in configfile parser

### DIFF
--- a/helpme/helpme.py
+++ b/helpme/helpme.py
@@ -512,7 +512,7 @@ node!  Be prepared to lose your funds (but please report a bug if you do!)
                     continue
                 parts = l2.split('=', 1)
                 if len(parts) == 1:
-                    parts[1] = None
+                    parts.append(None)
                 config[parts[0]].append(parts[1])
     except FileNotFoundError:
         pass


### PR DESCRIPTION
Within the if-block the list `parts` obviously only consists of one element, so the access `[1]` fails. 

Probably fixes #59 