### PR TITLE
Fix an issue with unchecked dict field access in jitrebalance

### DIFF
--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -138,7 +138,7 @@ def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
     peer = None
     for p in peers:
         for c in p['channels']:
-            if c['short_channel_id'] == scid:
+            if 'short_channel_id' in c and c['short_channel_id'] == scid:
                 chan = c
                 peer = p
 

--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -154,6 +154,13 @@ def on_htlc_accepted(htlc, onion, plugin, request, **kwargs):
     #funder = chan['msatoshi_to_us_max'] == chan['msatoshi_total']
     forward_amt = Millisatoshi(onion['forward_amount'])
 
+    # If we have enough capacity just let it through now. Otherwise the
+    # Millisatoshi raises an error for negative amounts in the calculation
+    # below.
+    if forward_amt < chan['spendable_msat']:
+        request.set_result({"result": "continue"})
+        return
+
     # Compute the amount we need to rebalance, give us a bit of breathing room
     # while we're at it (25% more rebalancing than strictly necessary) so we
     # don't end up with a completely unbalanced channel right away again, and

--- a/jitrebalance/test_jitrebalance.py
+++ b/jitrebalance/test_jitrebalance.py
@@ -79,7 +79,6 @@ def test_simple_rebalance(node_factory):
     l1.rpc.waitsendpay(inv['payment_hash'])
 
 
-@pytest.mark.xfail(strict=True)
 def test_issue_88(node_factory):
     """Reproduce issue #88: crash due to unconfirmed channel.
 


### PR DESCRIPTION
Fixes two issues in the jitrebalance plugin:

 - Unchecked access to a `dict` field: we were accessing the `short_channel_id` key in the channel `dict`, which is not safe for unconfirmed channels. This would crash the plugin, taking the rest of the node with it.
 - The `Millisatoshi` class includes checks for negative numbers, which were a bit overzealous. We not check before doing the computation, and return early if the channel capacity is sufficient.

Fixes #88 