### PR TITLE
Jitrebalance fixes

### DIFF
--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -92,7 +92,8 @@ def try_rebalance(scid, chan, amt, peer, request):
         except RpcError as e:
             error = e.error['data']
             erring_channel = error['erring_channel']
-            exclusions.append(erring_channel)
+            erring_direction = error['erring_direction']
+            exclusions.append("{}/{}".format(erring_channel, erring_direction))
             plugin.log("Excluding {} due to a failed attempt".format(erring_channel))
 
     request.set_result({"result": "continue"})

--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -10,17 +10,20 @@ import time
 plugin = Plugin()
 
 
+def get_reverse_chan(scid, chan):
+    for c in plugin.rpc.listchannels(scid)['channels']:
+        if c['channel_flags'] != chan['direction']:
+            return c
+
+    return None
+
 def get_circular_route(scid, chan, amt, peer, exclusions, request):
     """Compute a circular route with `scid` as last leg.
 
     """
     # Compute the last leg of the route first, so we know the parameters to
     # traverse that last edge.
-    reverse_chan = plugin.rpc.listchannels(scid)['channels']
-    assert(len(reverse_chan) == 2)
-    reverse_chan = [
-        c for c in reverse_chan if c['channel_flags'] != chan['direction']
-    ][0]
+    reverse_chan = get_reverse_chan(scid, chan)
 
     if reverse_chan is None:
         print("Could not compute parameters for the last hop")

--- a/jitrebalance/jitrebalance.py
+++ b/jitrebalance/jitrebalance.py
@@ -91,10 +91,15 @@ def try_rebalance(scid, chan, amt, peer, request):
             return
         except RpcError as e:
             error = e.error['data']
-            erring_channel = error['erring_channel']
-            erring_direction = error['erring_direction']
-            exclusions.append("{}/{}".format(erring_channel, erring_direction))
-            plugin.log("Excluding {} due to a failed attempt".format(erring_channel))
+            # The erring_channel field can not be present (shouldn't happen) or
+            # can be "0x0x0"
+            erring_channel = error.get('erring_channel', '0x0x0')
+            if erring_channel != '0x0x0':
+                erring_direction = error['erring_direction']
+                exclusions.append("{}/{}".format(erring_channel,
+                                                 erring_direction))
+                plugin.log("Excluding {} due to a failed attempt"
+                           .format(erring_channel))
 
     request.set_result({"result": "continue"})
 


### PR DESCRIPTION
While testing https://github.com/lightningd/plugins/pull/114 for real, I encountered the following error at the first rebalancing attempt :
```
2020-05-25T09:18:57.477Z INFO plugin-jitrebalance.py: Excluding 620929x1921x1 due to a failed attempt
2020-05-25T09:18:57.531Z UNUSUAL plugin-jitrebalance.py: Exception in thread Thread-1:
2020-05-25T09:18:57.531Z UNUSUAL plugin-jitrebalance.py: Traceback (most recent call last):
2020-05-25T09:18:57.531Z UNUSUAL plugin-jitrebalance.py:   File \"/usr/lib/python3.5/threading.py\", line 914, in _bootstrap_inner
2020-05-25T09:18:57.531Z UNUSUAL plugin-jitrebalance.py:     self.run()
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:   File \"/usr/lib/python3.5/threading.py\", line 862, in run
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:     self._target(*self._args, **self._kwargs)
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:   File \"/home/bitcoin/clightning/plugins/jitrebalance/jitrebalance.py\", line 66, in try_rebalance
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:     route = get_circular_route(scid, chan, amt, peer, exclusions, request)
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:   File \"/home/bitcoin/clightning/plugins/jitrebalance/jitrebalance.py\", line 40, in get_circular_route
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:     cltv=last_cltv,
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:   File \"/usr/local/lib/python3.5/dist-packages/pyln/client/lightning.py\", line 670, in getroute
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:     return self.call(\"getroute\", payload)
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:   File \"/usr/local/lib/python3.5/dist-packages/pyln/client/lightning.py\", line 235, in call
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py:     raise RpcError(method, payload, resp['error'])
2020-05-25T09:18:57.532Z UNUSUAL plugin-jitrebalance.py: pyln.client.lightning.RpcError: RPC call failed: method: getroute, payload: {'riskfactor': 1, 'maxhops': 20, 'cltv': 24, 'exclude': ['628434x2300x1/0', '620929x1921x1'], 'id': '0318070901e08df311cdc6cdb8a0b4a43a3690c5b32d1fb9d8e99d1a625a65e5f2', 'msatoshi': 236373398}, error: {'message': '620929x1921x1 is not a valid short_channel_id/node_id', 'code': -32602}
```
The first commit fixes this and the second is a bit of hardening.

EDIT: Added a commit to fix #117