### PR TITLE
prometheus: give short channel id for scid fiels, not long one

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -162,7 +162,7 @@ class ChannelsCollector(BaseLnCollector):
         peers = self.rpc.listpeers()['peers']
         for p in peers:
             for c in p['channels']:
-                labels = [p['id'], c['channel_id']]
+                labels = [p['id'], c.get('short_channel_id', c.get('channel_id'))]
                 balance_gauge.add_metric(labels, c['to_us_msat'].to_satoshi())
                 spendable_gauge.add_metric(labels,
                                            c['spendable_msat'].to_satoshi())


### PR DESCRIPTION
For example : `lightning_channel_htlcs{id="02065e25c272203440b66ea0ba66601d1248564554d0a68472b82511af54288120",scid="f93c2d2af0f1abf88b77bd2f014e06fbf064c18199ddb20e197195b2dc492b6c"} 1.0`