### PR TITLE
Limit channel size, don't require confirmations for channel funding

### DIFF
--- a/autopilot/autopilot.py
+++ b/autopilot/autopilot.py
@@ -104,11 +104,11 @@ class CLightning_autopilot(Autopilot):
         connection_dict = self.calculate_proposed_channel_capacities(pdf, balance)
         for nodeid, fraction in connection_dict.items():
             try:
-                satoshis = math.ceil(balance * fraction)
+                satoshis = min(math.ceil(balance * fraction), 16777215)
                 print("Try to open channel with a capacity of {} to node {}".format(satoshis, nodeid))
                 if not dryrun:
                     self.__rpc_interface.connect(nodeid)
-                    self.__rpc_interface.fundchannel(nodeid, satoshis)
+                    self.__rpc_interface.fundchannel(nodeid, satoshis, None, True, 0)
             except ValueError as e:
                 print("Could not open a channel to {} with capacity of {}. Error: {}".format(nodeid, satoshis, str(e)))
 

--- a/autopilot/lib_autopilot.py
+++ b/autopilot/lib_autopilot.py
@@ -325,8 +325,8 @@ class Autopilot():
             capacity = sum([self.G.get_edge_data(k, n)["satoshis"]
                             for n in neighbors])
             name = k
-            if "alias" in self.G.node[k]:
-                name = self.G.node[k]["alias"]
+            if "alias" in self.G.nodes[k]:
+                name = self.G.nodes[k]["alias"]
             print("{:12.2f}  ".format(100 * v),
                   "{:12.2f}     ".format(
                       100 * (w * v + (1 - w) / len(candidates))),
@@ -414,8 +414,8 @@ class Autopilot():
         """
         following code prints a list of candidates for debugging
         for k in res:
-            if "alias" in self.G.node[key[k]]:
-                print(pdf[key[k]], self.G.node[key[k]]["alias"])
+            if "alias" in self.G.nodes[key[k]]:
+                print(pdf[key[k]], self.G.nodes[key[k]]["alias"])
         """
 
         if len(candidats) > num_items:


### PR DESCRIPTION
This fixes two problems my autopilot kept running into:
1) trying to fund too large channels, which failed for this reason

2) having only one UTXO, which backfired when it tried to fund more than one channel via autopilot at once, as it would only accept UTXOs with several confirmations to fund a channel. So only the first channel got funded and then I got errors for all others as the new UTXOs were still unconfirmed. 