### PR TITLE
summary: fix persistent peerstate zero leading window

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -46,7 +46,7 @@ class PeerThread(threading.Thread):
             try:
                 rpcpeers = plugin.rpc.listpeers()
                 trace_availability(plugin, rpcpeers)
-                plugin.avail_peerstate.sync()
+                plugin.persist.sync()
                 time.sleep(plugin.avail_interval)
             except Exception as ex:
                 plugin.log("[PeerThread] " + str(ex), 'warn')
@@ -143,7 +143,7 @@ def summary(plugin, exclude=''):
                 c['private'],
                 p['connected'],
                 c['short_channel_id'],
-                plugin.avail_peerstate[pid]['avail']
+                plugin.persist['peerstate'][pid]['avail']
             ))
 
         if not active_channel and p['connected']:
@@ -224,10 +224,12 @@ def init(options, configuration, plugin):
     plugin.currency_prefix = options['summary-currency-prefix']
     plugin.fiat_per_btc = 0
 
-    plugin.avail_peerstate = shelve.open('summary.dat', writeback=True)
-    plugin.avail_count     = 0
     plugin.avail_interval  = float(options['summary-availability-interval'])
     plugin.avail_window    = 60 * 60 * int(options['summary-availability-window'])
+    plugin.persist         = shelve.open('summary.dat', writeback=True)
+    if not 'peerstate' in plugin.persist:
+        plugin.persist['peerstate'] = {}
+        plugin.persist['availcount'] = 0
 
     info = plugin.rpc.getinfo()
 

--- a/summary/summary_avail.py
+++ b/summary/summary_avail.py
@@ -3,8 +3,8 @@ from datetime import datetime
 # ensure an rpc peer is added
 def addpeer(p, rpcpeer):
     pid = rpcpeer['id']
-    if not pid in p.avail_peerstate:
-        p.avail_peerstate[pid] = {
+    if not pid in p.persist['peerstate']:
+        p.persist['peerstate'][pid] = {
             'connected' : rpcpeer['connected'],
             'last_seen' : datetime.now() if rpcpeer['connected'] else None,
             'avail' : 1.0 if rpcpeer['connected'] else 0.0
@@ -13,8 +13,8 @@ def addpeer(p, rpcpeer):
 
 # exponetially smooth online/offline states of peers
 def trace_availability(p, rpcpeers):
-    p.avail_count += 1
-    leadwin = max(min(p.avail_window, p.avail_count * p.avail_interval), p.avail_interval)
+    p.persist['availcount'] += 1
+    leadwin = max(min(p.avail_window, p.persist['availcount'] * p.avail_interval), p.avail_interval)
     samples = leadwin / p.avail_interval
     alpha   = 1.0 / samples
     beta    = 1.0 - alpha
@@ -24,9 +24,9 @@ def trace_availability(p, rpcpeers):
         addpeer(p, rpcpeer)
 
         if rpcpeer['connected']:
-            p.avail_peerstate[pid]['last_seen'] = datetime.now()
-            p.avail_peerstate[pid]['connected'] = True
-            p.avail_peerstate[pid]['avail']     = 1.0 * alpha + p.avail_peerstate[pid]['avail'] * beta
+            p.persist['peerstate'][pid]['last_seen'] = datetime.now()
+            p.persist['peerstate'][pid]['connected'] = True
+            p.persist['peerstate'][pid]['avail']     = 1.0 * alpha + p.persist['peerstate'][pid]['avail'] * beta
         else:
-            p.avail_peerstate[pid]['connected'] = False
-            p.avail_peerstate[pid]['avail']     = 0.0 * alpha + p.avail_peerstate[pid]['avail'] * beta
+            p.persist['peerstate'][pid]['connected'] = False
+            p.persist['peerstate'][pid]['avail']     = 0.0 * alpha + p.persist['peerstate'][pid]['avail'] * beta


### PR DESCRIPTION
Recovered persistent availability data was average out too fast, as a restarted node came up with a peerstate thread execution count of 0. Because the count being 0 the shortened leading exponential smoothing window was too small, leading to the situation that the recovered data was average out very quickly.

This commit takes the avail_count variable into the persistent state and adds a test.