### PR TITLE
sauron: Add retry HTTP adapter to retry requests up to 10 times

### DIFF
--- a/sauron/sauron.py
+++ b/sauron/sauron.py
@@ -2,6 +2,8 @@
 import sys
 import requests
 
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 from art import sauron_eye
 from pyln.client import Plugin
 
@@ -21,6 +23,17 @@ def fetch(url):
     # transaction a certain amount of times.
     session = requests.session()
     session.proxies = plugin.sauron_socks_proxies
+    retry_strategy = Retry(
+        backoff_factor=1,
+        total=10,
+        status_forcelist=[429, 500, 502, 503, 504],
+        method_whitelist=["HEAD", "GET", "OPTIONS"]
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+
     return session.get(url)
 
 


### PR DESCRIPTION
Sauron would fail with a 500 error or 429 error from time to time, so we now retry with a linear backoff.

Ping @darosior :-)