### PR TITLE
prometheus: Change default port to 9750 as per port-allocation

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -5,7 +5,7 @@ so it can be scraped, plotted and alerts can be created on it. The plugin adds
 the following command line arguments:
 
  - `prometheus-listen`: the IP address and port to bind the HTTP server to
-   (default: `0.0.0.0:9900`)
+   (default: `0.0.0.0:9750`)
    
 Exposed variables include:
 

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -213,7 +213,7 @@ def init(options, configuration, plugin):
 
 plugin.add_option(
     'prometheus-listen',
-    '0.0.0.0:9900',
+    '0.0.0.0:9750',
     'Address and port to bind to'
 )
 


### PR DESCRIPTION
We registered port 9750 the [port allocation] list for the prometheus project,
so we should use that port :-)

The addition to the list of known exporters is still pending https://github.com/prometheus/docs/pull/1737

Suggested-by: Martin Milata <@mmilata>
Fixes #122
[port allocation]: https://github.com/prometheus/prometheus/wiki/Default-port-allocations