### PR TITLE
Fixes bug for retrieving last message

### DIFF
--- a/noise/noise.py
+++ b/noise/noise.py
@@ -155,7 +155,7 @@ def sendmsg(node_id, msg, plugin, request, pay=None, **kwargs):
 @plugin.async_method('recvmsg')
 def recvmsg(plugin, request, last_id=None, **kwargs):
     next_id = int(last_id) + 1 if last_id is not None else len(plugin.messages)
-    if next_id < len(plugin.messages):
+    if next_id <= len(plugin.messages):
         request.set_result(plugin.messages[int(last_id)].to_dict())
     else:
         plugin.receive_waiters.append(request)


### PR DESCRIPTION
There was an off by one bug which resulted where `lightning-cli recvmsg <messages.count - 1>` would wait for the next message instead of returning the final message. 