### PR TITLE
feeadjuster: a plugin to adjust fees depending on channel balancing

### DIFF
--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -50,11 +50,13 @@ def get_chan(plugin: Plugin, scid: str):
     for peer in plugin.rpc.listpeers()["peers"]:
         if len(peer["channels"]) == 0:
             continue
-        chan = peer["channels"][0]
-        if "short_channel_id" not in chan:
-            continue
-        if chan["short_channel_id"] == scid:
-            return chan
+        # We might have multiple channel entries ! Eg if one was just closed
+        # and reopened.
+        for chan in peer["channels"]:
+            if "short_channel_id" not in chan:
+                continue
+            if chan["short_channel_id"] == scid:
+                return chan
 
 
 def maybe_add_new_balances(plugin: Plugin, scids: list):

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from concurrent.futures import ThreadPoolExecutor
+from pyln.client import Plugin, Millisatoshi, RpcError
+
+
+plugin = Plugin()
+# Our amount and the total amount in each of our channel, indexed by scid
+plugin.adj_balances = {}
+# Make requests to lightningd in parallel
+plugin.adj_thread_pool = None
+# Cache to avoid loads of calls to getinfo
+plugin.our_node_id = None
+
+
+def get_ratio(our_percentage):
+    """
+    Basic algorithm: the farther we are from the optimal case, the more we
+    bump/lower.
+    """
+    return 50**(0.5 - our_percentage)
+
+
+def get_fees(plugin: Plugin, scid: str):
+    for half in plugin.rpc.listchannels(scid)["channels"]:
+        if plugin.our_node_id in half["source"]:
+            return (half["base_fee_millisatoshi"], half["fee_per_millionth"])
+
+    # Note: the half may not be present, so this may actually return None!
+
+
+def maybe_adjust_fees(plugin: Plugin, scids: list):
+    for scid in scids:
+        # FIXME: set a threshold to avoid flooding!
+        if True:
+            # FIXME: it's exponential! We need to cache the startup
+            # fees instead of always factorising the updated ones.
+            fees = get_fees(plugin, scid)
+            if fees is None:
+                return
+
+            our = plugin.adj_balances[scid]["our"]
+            total = plugin.adj_balances[scid]["total"]
+            ratio = get_ratio(our / total)
+            try:
+                plugin.rpc.setchannelfee(scid, int(fees[0] * ratio),
+                                         int(fees[1] * ratio))
+                plugin.log("Adjusted fees of {} with a ratio of {}"
+                           .format(scid, ratio))
+            except RpcError as e:
+                plugin.log(str(e), level="warn")
+
+
+def get_chan(plugin: Plugin, scid: str):
+    for peer in plugin.rpc.listpeers()["peers"]:
+        if len(peer["channels"]) == 0:
+            continue
+        chan = peer["channels"][0]
+        if "short_channel_id" not in chan:
+            continue
+        if chan["short_channel_id"] == scid:
+            return chan
+
+
+def maybe_add_new_balances(plugin: Plugin, scids: list):
+    for scid in scids:
+        if scid not in plugin.adj_balances:
+            # At this point we could call listchannels and pass the scid as
+            # argument, and deduce the peer id (!our_id). But -as unlikely as
+            # it is- we may not find it in our gossip (eg some corruption of
+            # the gossip_store occured just before the forwarding event).
+            # However, it MUST be present in a listpeers() entry.
+            chan = get_chan(plugin, scid)
+            assert chan is not None
+
+            plugin.adj_balances[scid] = {
+                "our": int(chan["to_us_msat"]),
+                "total": int(chan["total_msat"])
+            }
+
+
+def threaded_forward_event(plugin: Plugin, forward_event: dict):
+    in_scid = forward_event["in_channel"]
+    out_scid = forward_event["out_channel"]
+    maybe_add_new_balances(plugin, [in_scid, out_scid])
+
+    plugin.adj_balances[in_scid]["our"] += forward_event["in_msatoshi"]
+    plugin.adj_balances[out_scid]["our"] -= forward_event["out_msatoshi"]
+    maybe_adjust_fees(plugin, [in_scid, out_scid])
+
+
+@plugin.subscribe("forward_event")
+def forward_event(plugin: Plugin, forward_event: dict, **kwargs):
+    if forward_event["status"] == "settled":
+        plugin.adj_thread_pool.submit(threaded_forward_event,
+                                      plugin, forward_event)
+
+
+@plugin.init()
+def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
+    plugin.our_node_id = plugin.rpc.getinfo()["id"]
+    plugin.adj_thread_pool = ThreadPoolExecutor(
+        max_workers=int(options["feeadjuster-par"])
+    )
+
+    for peer in plugin.rpc.listpeers()["peers"]:
+        if len(peer["channels"]) == 0:
+            continue
+        chan = peer["channels"][0]
+        if "short_channel_id" not in chan:
+            continue
+        if chan["state"] != "CHANNELD_NORMAL":
+            continue
+
+    plugin.log("Plugin feeadjuster initialized with {} threads"
+               .format(options["feeadjuster-par"]))
+
+
+plugin.add_option("feeadjuster-par", 8, "Maximum number of threads launched to"
+                  "adjust fees", opt_type="int")
+plugin.run()

--- a/feeadjuster/requirements.txt
+++ b/feeadjuster/requirements.txt
@@ -1,0 +1,1 @@
+pyln-client>=0.8.2

--- a/feeadjuster/test_feeadjuster.py
+++ b/feeadjuster/test_feeadjuster.py
@@ -61,7 +61,8 @@ def test_feeadjuster_adjusts(node_factory):
     l2_opts = {
         "fee-base": base_fee,
         "fee-per-satoshi": ppm_fee,
-        "plugin": plugin_path
+        "plugin": plugin_path,
+        "feeadjuster-deactivate-fuzz": None,
     }
     l1, l2, l3 = node_factory.line_graph(3, opts=[{}, l2_opts, {}],
                                          wait_for_announce=True)

--- a/feeadjuster/test_feeadjuster.py
+++ b/feeadjuster/test_feeadjuster.py
@@ -1,0 +1,125 @@
+import os
+import random
+import string
+import time
+
+import unittest
+from pyln.client import RpcError
+from pyln.testing.fixtures import *  # noqa: F401,F403
+from pyln.testing.utils import DEVELOPER, wait_for
+
+
+plugin_path = os.path.join(os.path.dirname(__file__), "feeadjuster.py")
+
+
+def test_feeadjuster_starts(node_factory):
+    l1 = node_factory.get_node()
+    # Test dynamically
+    l1.rpc.plugin_start(plugin_path)
+    assert l1.daemon.is_in_log("Plugin feeadjuster initialized.*")
+    l1.rpc.plugin_stop(plugin_path)
+    l1.rpc.plugin_start(plugin_path)
+    assert l1.daemon.is_in_log("Plugin feeadjuster initialized.*")
+    l1.stop()
+    # Then statically
+    l1.daemon.opts["plugin"] = plugin_path
+    l1.start()
+    assert l1.daemon.is_in_log("Plugin feeadjuster initialized.*")
+
+
+def get_chan_fees(l, scid):
+    for half in l.rpc.listchannels(scid)["channels"]:
+        if l.info["id"] == half["source"]:
+            return (half["base_fee_millisatoshi"], half["fee_per_millionth"])
+
+
+def pay(l, ll, amount):
+    label = ''.join(random.choices(string.ascii_letters, k=20))
+    invoice = ll.rpc.invoice(amount, label, "desc")
+    route = l.rpc.getroute(ll.info["id"], amount, riskfactor=0, fuzzpercent=0)
+    l.rpc.sendpay(route["route"], invoice["payment_hash"])
+    l.rpc.waitsendpay(invoice["payment_hash"])
+
+
+def sync_gossip(l, ll, scid):
+    wait_for(lambda: l.rpc.listchannels(scid) == ll.rpc.listchannels(scid))
+
+
+@unittest.skipIf(not DEVELOPER, "Too slow without fast gossip")
+def test_feeadjuster_adjusts(node_factory):
+    """
+    A rather simple network:
+
+            A                   B
+    l1  <========>   l2   <=========>  l3
+
+    l2 will adjust its configuration-set base and proportional fees for
+    channels A and B as l1 and l3 exchange payments.
+    """
+    base_fee = 5000
+    ppm_fee = 300
+    l2_opts = {
+        "fee-base": base_fee,
+        "fee-per-satoshi": ppm_fee,
+        "plugin": plugin_path
+    }
+    l1, l2, l3 = node_factory.line_graph(3, opts=[{}, l2_opts, {}],
+                                         wait_for_announce=True)
+
+    chan_A = l2.rpc.listpeers(l1.info["id"])["peers"][0]["channels"][0]
+    chan_B = l2.rpc.listpeers(l3.info["id"])["peers"][0]["channels"][0]
+    scid_A = chan_A["short_channel_id"]
+    scid_B = chan_B["short_channel_id"]
+    l2_scids = [scid_A, scid_B]
+
+    # Fees don't get updated until there is a forwarding event!
+    assert all([get_chan_fees(l2, scid) == (base_fee, ppm_fee)
+                for scid in l2_scids])
+
+    chan_total = int(chan_A["total_msat"])
+    assert chan_total == int(chan_B["total_msat"])
+
+    # The first payment will trigger fee adjustment, no matter its value
+    amount = int(chan_total * 0.04)
+    pay(l1, l3, amount)
+    wait_for(lambda: all([get_chan_fees(l2, scid) != (base_fee, ppm_fee)
+                          for scid in l2_scids]))
+
+    # Send most of the balance to the other side..
+    amount = int(chan_total * 0.8)
+    pay(l1, l3, amount)
+    wait_for(lambda: l2.daemon.is_in_log("Adjusted fees of {} with a ratio of"
+                                         " 0.2".format(scid_A)) is not None)
+    wait_for(lambda: l2.daemon.is_in_log("Adjusted fees of {} with a ratio of"
+                                         " 3.".format(scid_B)) is not None)
+
+    # ..And back
+    for scid in l2_scids:
+        sync_gossip(l3, l2, scid)
+        sync_gossip(l1, l2, scid)
+    pay(l3, l1, amount)
+    wait_for(lambda: l2.daemon.is_in_log("Adjusted fees of {} with a ratio of"
+                                         " 6.".format(scid_A)) is not None)
+    wait_for(lambda: l2.daemon.is_in_log("Adjusted fees of {} with a ratio of"
+                                         " 0.1".format(scid_B)) is not None)
+
+    # Sending a payment worth 3% of the channel balance should not trigger
+    # fee adjustment
+    for scid in l2_scids:
+        sync_gossip(l3, l2, scid)
+        sync_gossip(l1, l2, scid)
+    fees_before = [get_chan_fees(l2, scid) for scid in [scid_A, scid_B]]
+    amount = int(chan_total * 0.03)
+    pay(l1, l3, amount)
+    for scid in l2_scids:
+        sync_gossip(l3, l2, scid)
+        sync_gossip(l1, l2, scid)
+    assert fees_before == [get_chan_fees(l2, scid) for scid in l2_scids]
+
+    # But sending another 3%-worth payment does trigger adjustment (total sent
+    # since last adjustment is >5%)
+    pay(l1, l3, amount)
+    wait_for(lambda: l2.daemon.is_in_log("Adjusted fees of {} with a ratio of"
+                                         " 4.".format(scid_A)) is not None)
+    wait_for(lambda: l2.daemon.is_in_log("Adjusted fees of {} with a ratio of"
+                                         " 0.2".format(scid_B)) is not None)


### PR DESCRIPTION
This is really just a sketch, but i wanted to share the algorithm with you in case you have inputs.

This is structured such as it should be easy to set the `get_ratio` function depending on configuration flags. For example we can imagine a `--feeadjust-algo` option which would default to `basic` and just use the current one, and a `greedy` value would biase the ratio depending on:
- the funds on our side (how much we are exposed)
- if we are the channel funder (even worse, in practice this is my main source of losses)
- maybe the number of HTLCs in flight (this would actually take YA rpc call)

While this is an experiment i expect to run this on a node forwarding a substantial number of payments per day, so care has been taken to minimize the impact (mainly reduce the number of RPC calls).

I need to set up a threshold to avoid flooding, maybe "don't update if it didn't move more than 1% of the funds" so it needs more caching.

This is currently exponential, and i don't think it's the right thing as the adjustment strength will depend on the number of payments and not the proportion of funds.

I gathered some feedback from @renepickhardt and @whitslack by mail too, so if any of you want to weigh in please do :-)