### PR TITLE
chore: feeadjuster additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Community curated plugins for c-lightning.
 | [donations][donations]             | A simple donations page to accept donations from the web                                  |
 | [drain][drain]                     | Draining, filling and balancing channels with automatic chunks.                           |
 | [event-websocket][event-websocket] | Exposes notifications over a Websocket                                                    |
+| [feeadjuster][feeadjuster]         | Dynamic fees to keep your channels more balanced                                          |
 | [graphql][graphql]                 | Exposes the c-lightning API over [graphql][graphql-spec]                                  |
 | [invoice-queue][invoice-queue]     | Listen to lightning invoices from multiple nodes and send to a redis queue for processing |
 | [lightning-qt][lightning-qt]       | A bitcoin-qt-like GUI for lightningd                                                      |
@@ -171,3 +172,4 @@ your environment.
 [event-websocket]: https://github.com/rbndg/c-lightning-events
 [invoice-queue]: https://github.com/rbndg/Lightning-Invoice-Queue
 [boltz]: https://github.com/BoltzExchange/channel-creation-plugin
+[feeadjuster]: https://github.com/lightningd/plugins/tree/master/feeadjuster

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -105,15 +105,6 @@ def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
     plugin.adj_basefee = config["fee-base"]
     plugin.adj_ppmfee = config["fee-per-satoshi"]
 
-    for peer in plugin.rpc.listpeers()["peers"]:
-        if len(peer["channels"]) == 0:
-            continue
-        chan = peer["channels"][0]
-        if "short_channel_id" not in chan:
-            continue
-        if chan["state"] != "CHANNELD_NORMAL":
-            continue
-
     plugin.log("Plugin feeadjuster initialized ({} base / {} ppm) with a "
                "threshold of {}"
                .format(plugin.adj_basefee, plugin.adj_ppmfee,

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -10,7 +10,7 @@ plugin.adj_balances = {}
 # Cache to avoid loads of calls to getinfo
 plugin.our_node_id = None
 # Users can configure this
-plugin.update_treshold = 0.05
+plugin.update_threshold = 0.05
 
 
 def get_ratio(our_percentage):
@@ -30,12 +30,12 @@ def maybe_adjust_fees(plugin: Plugin, scids: list):
 
         # Only update on substantial balance moves to avoid flooding, and add
         # some pseudo-randomness to avoid too easy channel balance probing
-        update_treshold = plugin.update_treshold
+        update_threshold = plugin.update_threshold
         if not plugin.deactivate_fuzz:
-            update_treshold += random.uniform(-0.015, 0.015)
+            update_threshold += random.uniform(-0.015, 0.015)
 
         if (last_percentage is None
-                or abs(last_percentage - percentage) > update_treshold):
+                or abs(last_percentage - percentage) > update_threshold):
             ratio = get_ratio(percentage)
             try:
                 plugin.rpc.setchannelfee(scid, int(plugin.adj_basefee * ratio),
@@ -100,7 +100,7 @@ def forward_event(plugin: Plugin, forward_event: dict, **kwargs):
 def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
     plugin.our_node_id = plugin.rpc.getinfo()["id"]
     plugin.deactivate_fuzz = options.get("feeadjuster-deactivate-fuzz", False)
-    plugin.update_treshold = float(options.get("feeadjuster-threshold", "0.05"))
+    plugin.update_threshold = float(options.get("feeadjuster-threshold", "0.05"))
     config = plugin.rpc.listconfigs()
     plugin.adj_basefee = config["fee-base"]
     plugin.adj_ppmfee = config["fee-per-satoshi"]
@@ -117,7 +117,7 @@ def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
     plugin.log("Plugin feeadjuster initialized ({} base / {} ppm) with a "
                "threshold of {}"
                .format(plugin.adj_basefee, plugin.adj_ppmfee,
-                       plugin.update_treshold))
+                       plugin.update_threshold))
 
 
 plugin.add_option(
@@ -129,8 +129,8 @@ plugin.add_option(
 plugin.add_option(
     "feeadjuster-threshold",
     "0.05",
-    "Channel balance update threshold at which to trigger an update. Note "
-    "it's fuzzed.",
+    "Channel balance update threshold at which to trigger an update. "
+    "Note: it's also fuzzed by 1.5%",
     "string"
 )
 plugin.run()

--- a/feeadjuster/test_feeadjuster.py
+++ b/feeadjuster/test_feeadjuster.py
@@ -24,7 +24,7 @@ def test_feeadjuster_starts(node_factory):
     # Then statically
     l1.daemon.opts["plugin"] = plugin_path
     l1.start()
-    assert l1.daemon.is_in_log("Plugin feeadjuster initialized.*")
+    l1.daemon.wait_for_log("Plugin feeadjuster initialized.*")
 
 
 def get_chan_fees(l, scid):


### PR DESCRIPTION
These are my additions on the feeadjuster:
 - fix some typos
 - remove useless loop (again :)
 - adds `feeadjuster-imbalance`% config option that keeps the plugin from acting if imbalance is too low
 - add it to the repo's REAMDME.md link

**Note:** The default value for `feeadjuster-imbalance` is 50% (always on), as I didn't want to change current function and just improve on it. However, again, for privacy reasons I propose to use a value of i.e. 30% of letting the `feeadjuster` to set fees only when imbalance exceeds 30/70%. In any case, I can now use this value for myself now ;)

I think about adding an additional loop that sets default base/ppm fees on a per channel basis by doing some peer analysis as @zmnscpxj suggested. Maybe this can be an optional dedicated plugin that needs to run before is feeadjuster is started.