### PR TITLE
backup: Do not buffer early writes, instead rely on backup.lock to find and write to the backend

### DIFF
--- a/backup/backup.py
+++ b/backup/backup.py
@@ -299,6 +299,23 @@ def on_db_write(writes, data_version, plugin, **kwargs):
         kill("Could not append DB change to the backup. Need to shutdown!")
 
 
+@plugin.init()
+def on_init(options, **kwargs):
+    dest = options.get('backup-destination', 'null')
+    if dest != 'null':
+        plugin.log(
+            "The `--backup-destination` option is deprecated and will be "
+            "removed in future versions of the backup plugin. Please remove "
+            "it from your configuration. The destination is now determined by "
+            "the `backup.lock` file in the lightning directory",
+            level="warn"
+        )
+
+    configs = plugin.rpc.listconfigs()
+    if not configs['wallet'].startswith('sqlite3'):
+        kill("The backup plugin only works with the sqlite3 database.")
+
+
 def kill(message: str):
     plugin.log(message)
     time.sleep(1)

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -335,10 +335,6 @@ def on_init(options: Mapping[str, str], plugin: Plugin, **kwargs):
         apply_write(plugin, c)
 
 
-plugin.add_option(
-    'backup-destination', None,
-    'Destination of the database backups (file:///filename/on/another/disk/).'
-)
 
 
 def kill(message: str):
@@ -365,6 +361,12 @@ def preflight(plugin: Plugin):
     """
     if not os.path.exists("backup.lock"):
         kill("Could not find backup.lock in the lightning-dir")
+
+plugin.add_option(
+    'backup-destination', None,
+    'UNUSED. Kept for backward compatibility only. Please update your configuration to remove this option.'
+)
+
 
 if __name__ == "__main__":
     preflight(plugin)

--- a/backup/test_backup.py
+++ b/backup/test_backup.py
@@ -189,3 +189,21 @@ def test_restore(node_factory, directory):
 
     rdest = os.path.join(bpath, 'lightningd.sqlite.restore')
     subprocess.check_call([cli_path, "restore", bdest, rdest])
+
+
+def test_warning(directory, node_factory):
+    bpath = os.path.join(directory, 'lightning-1', 'regtest')
+    bdest = 'file://' + os.path.join(bpath, 'backup.dbak')
+    os.makedirs(bpath)
+    subprocess.check_call([cli_path, "init", bpath, bdest])
+    opts = {
+        'plugin': plugin_path,
+        'allow-deprecated-apis': deprecated_apis,
+        'backup-destination': 'somewhere/over/the/rainbox',
+    }
+    l1 = node_factory.get_node(options=opts, cleandir=False)
+    l1.stop()
+
+    assert(l1.daemon.is_in_log(
+        r'The `--backup-destination` option is deprecated and will be removed in future versions of the backup plugin.'
+    ))


### PR DESCRIPTION
We address #155 by deprecating the `--backup-destination` CLI option, replacing it outright with the discovery based on the `backup.lock` file, which is generated by `backup-cli init [lightning-dir] [backend-uri]`. This means that we can immediately start appending changes to the backup without having to wait for the `init` message from `lightningd` (at which point we'd already have some writes buffered).

The `--backup-destination` flag is still present so we don't break any config files, but we warn about it being present, and ask the operator to fix their config.

Fixes #155 