### PR TITLE
summary: use proxy if configuration says to.

### DIFF
--- a/summary/requirements.txt
+++ b/summary/requirements.txt
@@ -1,3 +1,4 @@
 pyln-client>=0.7.3
-requests>=2.0.0
+requests>=2.10.0
+requests[socks]>=2.10.0
 packaging>=14.1


### PR DESCRIPTION
All plugins should take care to do this if config
specifies always-use-proxy!

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>