### PR TITLE
Backup: restore without filename

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -58,5 +58,5 @@ If things really messed up and you reinstall clightning on a new host, you can
 restore the database backup by using the `backup-cli` utility:
 
 ```bash
-./backup-cli restore file:///mnt/external/location ~/.lightning/bitcoin
+./backup-cli restore file:///mnt/external/location ~/.lightning/bitcoin/lightningd.sqlite3
 ```

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -103,8 +103,12 @@ class Backend(object):
 
     def restore(self, dest: str, remove_existing: bool = False):
         """Restore the backup in this backend to its former glory.
-        """
 
+        If `dest` is a directory, we assume the default database filename:
+        lightningd.sqlite3
+        """
+        if os.path.isdir(dest):
+            dest = os.path.join(dest, "lightningd.sqlite3")
         if os.path.exists(dest):
             if not remove_existing:
                 raise ValueError(

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -231,7 +231,6 @@ class FileBackend(Backend):
             assert(version == self.version)
 
 
-
 def resolve_backend_class(backend_url):
     backend_map: Mapping[str, Type[Backend]] = {
         'file': FileBackend,
@@ -337,7 +336,6 @@ def kill(message: str):
     # Sleep forever, just in case the master doesn't die on us...
     while True:
         time.sleep(30)
-
 
 
 plugin.add_option(

--- a/backup/test_backup.py
+++ b/backup/test_backup.py
@@ -1,7 +1,5 @@
 from flaky import flaky
-from pyln.client import RpcError
-from pyln.testing.fixtures import *
-from pyln.client import RpcError
+from pyln.testing.fixtures import *  # noqa: F401,F403
 import os
 import pytest
 import subprocess
@@ -14,6 +12,7 @@ cli_path = os.path.join(os.path.dirname(__file__), "backup-cli")
 # For the transition period we require deprecated_apis to be true
 deprecated_apis = True
 
+
 def test_start(node_factory, directory):
     bpath = os.path.join(directory, 'lightning-1', 'regtest')
     bdest = 'file://' + os.path.join(bpath, 'backup.dbak')
@@ -22,7 +21,7 @@ def test_start(node_factory, directory):
     opts = {
         'plugin': plugin_path,
         'allow-deprecated-apis': deprecated_apis,
-        }
+    }
     l1 = node_factory.get_node(options=opts, cleandir=False)
     plugins = [os.path.basename(p['name']) for p in l1.rpc.plugin("list")['plugins']]
     assert("backup.py" in plugins)
@@ -38,7 +37,6 @@ def test_start_no_init(node_factory, directory):
     """The plugin should refuse to start if we haven't initialized the backup
     """
     bpath = os.path.join(directory, 'lightning-1', 'regtest')
-    bdest = 'file://' + os.path.join(bpath, 'backup.dbak')
     os.makedirs(bpath)
     opts = {
         'plugin': plugin_path,
@@ -94,7 +92,7 @@ def test_tx_abort(node_factory, directory):
     opts = {
         'plugin': plugin_path,
         'allow-deprecated-apis': deprecated_apis,
-        }
+    }
     l1 = node_factory.get_node(options=opts, cleandir=False)
     l1.stop()
 
@@ -124,10 +122,10 @@ def test_failing_restore(node_factory, directory):
     opts = {
         'plugin': plugin_path,
         'allow-deprecated-apis': deprecated_apis,
-        }
+    }
 
     def section(comment):
-        print("="*25, comment, "="*25)
+        print("=" * 25, comment, "=" * 25)
 
     section("Starting node for the first time")
     l1 = node_factory.get_node(options=opts, cleandir=False, may_fail=True)
@@ -157,7 +155,7 @@ def test_intermittent_backup(node_factory, directory):
     opts = {
         'plugin': plugin_path,
         'allow-deprecated-apis': deprecated_apis,
-        }
+    }
     l1 = node_factory.get_node(options=opts, cleandir=False, may_fail=True)
 
     # Now start without the plugin. This should work fine.
@@ -183,7 +181,7 @@ def test_restore(node_factory, directory):
     opts = {
         'plugin': plugin_path,
         'allow-deprecated-apis': deprecated_apis,
-        }
+    }
     l1 = node_factory.get_node(options=opts, cleandir=False)
     l1.stop()
 
@@ -199,7 +197,7 @@ def test_restore_dir(node_factory, directory):
     opts = {
         'plugin': plugin_path,
         'allow-deprecated-apis': deprecated_apis,
-        }
+    }
     l1 = node_factory.get_node(options=opts, cleandir=False)
     l1.stop()
 

--- a/backup/test_backup.py
+++ b/backup/test_backup.py
@@ -191,6 +191,27 @@ def test_restore(node_factory, directory):
     subprocess.check_call([cli_path, "restore", bdest, rdest])
 
 
+def test_restore_dir(node_factory, directory):
+    bpath = os.path.join(directory, 'lightning-1', 'regtest')
+    bdest = 'file://' + os.path.join(bpath, 'backup.dbak')
+    os.makedirs(bpath)
+    subprocess.check_call([cli_path, "init", bpath, bdest])
+    opts = {
+        'plugin': plugin_path,
+        'allow-deprecated-apis': deprecated_apis,
+        }
+    l1 = node_factory.get_node(options=opts, cleandir=False)
+    l1.stop()
+
+    # should raise error without remove_existing
+    with pytest.raises(Exception):
+        subprocess.check_call([cli_path, "restore", bdest, bpath])
+
+    # but succeed when we remove the sqlite3 dbfile before
+    os.remove(os.path.join(bpath, "lightningd.sqlite3"))
+    subprocess.check_call([cli_path, "restore", bdest, bpath])
+
+
 def test_warning(directory, node_factory):
     bpath = os.path.join(directory, 'lightning-1', 'regtest')
     bdest = 'file://' + os.path.join(bpath, 'backup.dbak')


### PR DESCRIPTION
- fix readme to restore to a filename not just a dir
- adds the option to restore to just a dir, in this case we assume `lightningd.sqlite3` as filename.
- fixes flake8 issues