### PR TITLE
Update the readme to include a Github Actions badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test plugins against recent c-lightning
+name: Integration Tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Community curated plugins for c-lightning.
 
-[![Build Status](https://travis-ci.org/lightningd/plugins.svg?branch=master)](https://travis-ci.org/lightningd/plugins)
+![Integration Tests](https://github.com/lightningd/plugins/workflows/Integration%20Tests/badge.svg)
 
 ## Available plugins
 


### PR DESCRIPTION
The travis badge is no longer useful.
