### PR TITLE
automatic rebalance

### DIFF
--- a/rebalance/README.md
+++ b/rebalance/README.md
@@ -1,6 +1,6 @@
 # Rebalance plugin
 
-This plugin moves liquidity between your channels using circular payments:
+This plugin moves liquidity between your channels using circular payments
 
 
 ## Installation
@@ -11,8 +11,41 @@ For general plugin installation instructions see the repos main
 
 ## Usage
 
-Once the plugin is installed and active, you can use the `lightning-cli` to
-rebalance channels like this:
+Once the plugin is installed and active, there are two additional methods to rebalance channels:
+1) Either you can call `lightning-cli rebalanceall` to automatically fix all of your channels' liquidity.
+2) Or you can call `lightning-cli rebalance outgoing_scid incoming_scid` to rebalance individual channels.
+
+## Automatic rebalance
+
+A lightning node usually has multiple channels of different sizes. The node can perform best if all channels have `{enough_liquidity}` for both directions. So the rebalance has multiple purposes with different priority:
+1) **The primary goal** is to ensure all channels have `{enough_liquidity}` for both direction, or if a given channel is too small for that, then it has a 50/50 liquidity ratio.
+2) **The secondary goal** is to distribute the remaining liquidity evenly between the big channels.
+3) For the long run, it is very important **to do this economically**. So the fees of fixing liquidity have to be cheaper than the fees of transaction forwards, which can ruin the liquidity again. (This assumes your node has some rational fee setting.) This way the automatic rebalance can run regularly, and your node can earn more on transaction forwarding than spend for rebalancing.
+
+If the plugin cannot find a cheap enough circular route to rebalancing economically, then it does nothing by default. To not to cause a loss for users.
+
+#### Rebalancing strategy
+
+As a first step, depending on the actual situation, there is a need to get a value of `{enough_liquidity}`. The plugin searches for a maximum possible threshold. For which all channels theoretically can be balanced beyond this threshold. Or smaller than `threshold * 2` channels can be balanced to a 50/50 ratio. `{enough_liquidity}` will be half of this maximum threshold.
+
+The next step is to calculate `{ideal_ratio}` for big channels. Beyond the `{enough_liquidity}` threshold, big channels should share the remaining liquidity evenly, so every big channels' liquidity ratio should be close to the `{ideal_ratio}`.
+
+After we know the current `{enough_liquidity}` threshold and `{ideal_ratio}`, the plugin checks every possible channel pairs to seek a proper rebalance opportunity. If it finds a matching pair, it calls the individual rebalance method for them. If the rebalance fails, the plugin tries again with a lesser amount, until it reaches the minimum rebalancable amount, or the rebalance succeeds.
+
+This process may take a while. Automatic rebalance can run for hours in the background.
+
+#### Parameters for automatic rebalance
+
+- OPTIONAL: The `min_amount` parameter sets the minimum rebalancable amount in millisatoshis. The parameter also can be specified in other denominations by appending a valid suffix, i. e. '1000000sat', '0.01btc' or '10mbtc'. The default value is '50000sat'.
+- OPTIONAL: The `feeratio` sets how much the rebalance may cost as a ratio of your default fee. Its default value is `0.5`, which means it can use a maximum of half of your node's default fee.
+
+#### Tips and Tricks for automatic rebalance
+
+- It may work only with well-connected nodes. You should have several different channels to use it with a good chance for success.
+- Your node should have some rational default fee setting. If you use cheaper fees than your neighbors, it probably cannot find a cheap enough circular route to rebalance.
+
+## Individual channel rebalance
+You can use the `lightning-cli` to rebalance channels like this:
 
 ```
 lightning-cli rebalance outgoing_scid incoming_scid [msatoshi] [maxfeepercent] [retry_for] [exemptfee]
@@ -25,7 +58,7 @@ use always the `lightning-cli -k` (key=value) syntax like this:
 lightning-cli rebalance -k outgoing_scid=1514942x51x0 incoming_scid=1515133x10x0 maxfeepercent=1
 ```
 
-### Parameters
+#### Parameters for individual rebalance
 
 - The `outgoing_scid` is the short_channel_id of the sending channel,
 - The `incoming_scid` is the short_channel_id of the receiving channel.
@@ -43,7 +76,7 @@ lightning-cli rebalance -k outgoing_scid=1514942x51x0 incoming_scid=1515133x10x0
   exemptfee (default: 5000 millisatoshi).
 
 
-## Tips and Tricks
+#### Tips and Tricks for individual rebalance
 
 - To find the correct channel IDs, you can use the `summary` plugin which can
   be found [here](https://github.com/lightningd/plugins/tree/master/summary).

--- a/rebalance/README.md
+++ b/rebalance/README.md
@@ -32,7 +32,7 @@ The next step is to calculate `{ideal_ratio}` for big channels. Beyond the `{eno
 
 After we know the current `{enough_liquidity}` threshold and `{ideal_ratio}`, the plugin checks every possible channel pairs to seek a proper rebalance opportunity. If it finds a matching pair, it calls the individual rebalance method for them. If the rebalance fails, the plugin tries again with a lesser amount, until it reaches the minimum rebalancable amount, or the rebalance succeeds.
 
-This process may take a while. Automatic rebalance can run for hours in the background.
+This process may take a while. Automatic rebalance can run for hours in the background, but you can stop it anytime with `lightning-cli rebalancestop`.
 
 #### Parameters for automatic rebalance
 

--- a/rebalance/README.md
+++ b/rebalance/README.md
@@ -34,7 +34,7 @@ After we know the current `{enough_liquidity}` threshold and `{ideal_ratio}`, th
 
 This process may take a while. Automatic rebalance can run for hours in the background, but you can stop it anytime with `lightning-cli rebalancestop`.
 
-#### Parameters for automatic rebalance
+#### Parameters for rebalanceall
 
 - OPTIONAL: The `min_amount` parameter sets the minimum rebalancable amount in millisatoshis. The parameter also can be specified in other denominations by appending a valid suffix, i. e. '1000000sat', '0.01btc' or '10mbtc'. The default value is '50000sat'.
 - OPTIONAL: The `feeratio` sets how much the rebalance may cost as a ratio of your default fee. Its default value is `0.5`, which means it can use a maximum of half of your node's default fee.
@@ -58,7 +58,7 @@ use always the `lightning-cli -k` (key=value) syntax like this:
 lightning-cli rebalance -k outgoing_scid=1514942x51x0 incoming_scid=1515133x10x0 maxfeepercent=1
 ```
 
-#### Parameters for individual rebalance
+#### Parameters for rebalance
 
 - The `outgoing_scid` is the short_channel_id of the sending channel,
 - The `incoming_scid` is the short_channel_id of the receiving channel.

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from pyln.client import Plugin, Millisatoshi, RpcError
+from threading import Thread, Lock
 import time
 import uuid
 
@@ -146,8 +147,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
     get_channel(plugin, payload, incoming_node_id, incoming_scid, True)
     out_ours, out_total = amounts_from_scid(plugin, outgoing_scid)
     in_ours, in_total = amounts_from_scid(plugin, incoming_scid)
-    plugin.log("Outgoing node: %s, channel: %s" % (outgoing_node_id, outgoing_scid))
-    plugin.log("Incoming node: %s, channel: %s" % (incoming_node_id, incoming_scid))
+    plugin.log("Outgoing node: %s, channel: %s" % (outgoing_node_id, outgoing_scid), 'debug')
+    plugin.log("Incoming node: %s, channel: %s" % (incoming_node_id, incoming_scid), 'debug')
 
     # If amount was not given, calculate a suitable 50/50 rebalance amount
     if msatoshi is None:
@@ -165,7 +166,6 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
     description = "%s to %s" % (outgoing_scid, incoming_scid)
     invoice = plugin.rpc.invoice(msatoshi, label, description, retry_for + 60)
     payment_hash = invoice['payment_hash']
-    plugin.log("Invoice payment_hash: %s" % payment_hash)
     success_msg = ""
     try:
         excludes = []
@@ -190,7 +190,9 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
                 excludes += [worst_channel_id + '/0', worst_channel_id + '/1']
                 continue
 
-            success_msg = "%d msat sent over %d hops to rebalance %d msat" % (msatoshi + fees, len(route), msatoshi)
+            success_msg = {"sent": int(msatoshi + fees), "received": int(msatoshi), "fee": int(fees), "hops": len(route),
+                           "outgoing_scid": outgoing_scid, "incoming_scid": incoming_scid, "status": "settled",
+                           "message": f"{int(msatoshi + fees):,} msat sent over {len(route)} hops to rebalance {int(msatoshi):,} msat"}
             plugin.log("Sending %s over %d hops to rebalance %s" % (msatoshi + fees, len(route), msatoshi), 'debug')
             for r in route:
                 plugin.log("    - %s  %14s  %s" % (r['id'], r['channel'], r['amount_msat']), 'debug')
@@ -201,7 +203,7 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
                 return success_msg
 
             except RpcError as e:
-                plugin.log("RpcError: " + str(e))
+                plugin.log("RpcError: " + str(e), 'debug')
                 erring_channel = e.error.get('data', {}).get('erring_channel')
                 if erring_channel == incoming_scid:
                     raise RpcError("rebalance", payload, {'message': 'Error with incoming channel'})
@@ -212,16 +214,260 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi=None,
                     excludes.append(erring_channel + '/' + str(erring_direction))
 
     except Exception as e:
-        plugin.log("Exception: " + str(e))
+        plugin.log("Exception: " + str(e), 'debug')
         return cleanup(plugin, label, payload, success_msg, e)
     return cleanup(plugin, label, payload, success_msg)
 
 
+def must_send(channel, enough_liquidity: int):
+    # liquidity is too high, must send some sats
+    min_liquidity = min(channel["msatoshi_total"] / 2, enough_liquidity)
+    their_liquidity = channel["msatoshi_total"] - channel["msatoshi_to_us"]
+    return max(0, min_liquidity - their_liquidity)
+
+
+def should_send(channel, enough_liquidity: int, ideal_ratio: float):
+    # liquidity is a bit high, would be good to send some sats
+    min_liquidity = min(channel["msatoshi_total"] / 2, enough_liquidity)
+    their_liquidity = channel["msatoshi_total"] - channel["msatoshi_to_us"]
+    their_ideal_liquidity = channel["msatoshi_total"] * (1 - ideal_ratio)
+    should_have = min(max(their_ideal_liquidity, min_liquidity), channel["msatoshi_total"] - min_liquidity)
+    return max(0, should_have - their_liquidity)
+
+
+def could_send(channel, enough_liquidity: int):
+    # liquidity maybe a bit low, but can send some more sats, if needed
+    min_liquidity = min(channel["msatoshi_total"] / 2, enough_liquidity)
+    our_liquidity = channel["msatoshi_to_us"]
+    return max(0, our_liquidity - min_liquidity)
+
+
+def must_receive(channel, enough_liquidity: int):
+    # liquidity is too low, must receive some sats
+    min_liquidity = min(channel["msatoshi_total"] / 2, enough_liquidity)
+    our_liquidity = channel["msatoshi_to_us"]
+    return max(0, min_liquidity - our_liquidity)
+
+
+def should_receive(channel, enough_liquidity: int, ideal_ratio: float):
+    # liquidity is a bit low, would be good to receive some sats
+    min_liquidity = min(channel["msatoshi_total"] / 2, enough_liquidity)
+    our_liquidity = channel["msatoshi_to_us"]
+    our_ideal_liquidity = channel["msatoshi_total"] * ideal_ratio
+    should_have = min(max(our_ideal_liquidity, min_liquidity), channel["msatoshi_total"] - min_liquidity)
+    return max(0, should_have - our_liquidity)
+
+
+def could_receive(channel, enough_liquidity: int):
+    # liquidity maybe a bit high, but can receive some more sats, if needed
+    min_liquidity = min(channel["msatoshi_total"] / 2, enough_liquidity)
+    their_liquidity = channel["msatoshi_total"] - channel["msatoshi_to_us"]
+    return max(0, their_liquidity - min_liquidity)
+
+
+def get_our_channels(plugin: Plugin):
+    channels = []
+    for peer in plugin.rpc.listpeers()["peers"]:
+        for ch in peer["channels"]:
+            if ch["state"] == "CHANNELD_NORMAL" and not ch["private"]:
+                channels.append(ch)
+    return channels
+
+
+def check_liquidity_threshold(channels: list, threshold: int):
+    # check if overall rebalances can be successful with this threshold
+    ours = sum(ch["msatoshi_to_us"] for ch in channels)
+    total = sum(ch["msatoshi_total"] for ch in channels)
+    required = 0
+    for ch in channels:
+        required += int(min(threshold, ch["msatoshi_total"] / 2))
+    return required < ours and required < total - ours
+
+
+def binary_search(channels: list, low: int, high: int):
+    if high - low < 1000:
+        return low
+    next_step = int((low + high) / 2)
+    if check_liquidity_threshold(channels, next_step):
+        return binary_search(channels, next_step, high)
+    else:
+        return binary_search(channels, low, next_step)
+
+
+def get_enough_liquidity_threshold(channels: list):
+    biggest_channel = max(channels, key=lambda ch: ch["msatoshi_total"])
+    max_threshold = binary_search(channels, 0, int(biggest_channel["msatoshi_total"] / 2))
+    return int(max_threshold / 2)
+
+
+def get_ideal_ratio(channels: list, enough_liquidity: int):
+    # ideal liquidity ratio for big channels:
+    # small channels should have a 50/50 liquidity ratio to be usable
+    # and big channels can store the remaining liquidity above the threshold
+    ours = sum(ch["msatoshi_to_us"] for ch in channels)
+    total = sum(ch["msatoshi_total"] for ch in channels)
+    chs = list(channels)
+    while True:
+        ratio = ours / total
+        smallest_channel = min(chs, key=lambda ch: ch["msatoshi_total"])
+        if smallest_channel["msatoshi_total"] * min(ratio, 1 - ratio) > enough_liquidity:
+            break
+        min_liquidity = min(smallest_channel["msatoshi_total"] / 2, enough_liquidity)
+        diff = smallest_channel["msatoshi_total"] * ratio
+        diff = max(diff, min_liquidity)
+        diff = min(diff, smallest_channel["msatoshi_total"] - min_liquidity)
+        ours -= diff
+        total -= smallest_channel["msatoshi_total"]
+        chs.remove(smallest_channel)
+    return ratio
+
+
+def feeadjust_would_be_nice(plugin: Plugin):
+    try:
+        msg = plugin.rpc.feeadjust()
+        plugin.log(f"Feeadjust succeeded: {msg}")
+    except Exception:
+        plugin.log("The feeadjuster plugin would be useful here")
+
+
+def get_max_amount(i: int, min_amount: int, enough_liquidity: int):
+    return max(min_amount, int(enough_liquidity / (4**(i + 1))))
+
+
+def get_max_fee(plugin: Plugin, msat: int):
+    # TODO: sanity check
+    base = int(plugin.get_option("fee-base"))
+    ppm = int(plugin.get_option("fee-per-satoshi"))
+    feeratio = float(plugin.get_option("feeratio"))
+    return int((base + ppm * msat / 1000000) * feeratio)
+
+
+def get_chan(plugin: Plugin, scid: str):
+    for peer in plugin.rpc.listpeers()["peers"]:
+        if len(peer["channels"]) == 0:
+            continue
+        # We might have multiple channel entries ! Eg if one was just closed
+        # and reopened.
+        for chan in peer["channels"]:
+            if "short_channel_id" not in chan:
+                continue
+            if chan["short_channel_id"] == scid:
+                return chan
+
+
+def maybe_rebalance_pairs(plugin: Plugin, ch1, ch2, failed_pairs: list):
+    scid1 = ch1["short_channel_id"]
+    scid2 = ch2["short_channel_id"]
+    result = {"success": False, "fee_spent": 0}
+    if scid1 + ":" + scid2 in failed_pairs:
+        return result
+    enough_liquidity = int(plugin.get_option("enough-liquidity"))
+    ideal_ratio = float(plugin.get_option("ideal-ratio"))
+    min_amount = int(Millisatoshi(plugin.get_option("min-amount")))
+    i = 0
+    while True:
+        amount1 = min(must_send(ch1, enough_liquidity), could_receive(ch2, enough_liquidity))
+        amount2 = min(should_send(ch1, enough_liquidity, ideal_ratio), should_receive(ch2, enough_liquidity, ideal_ratio))
+        amount3 = min(could_send(ch1, enough_liquidity), must_receive(ch2, enough_liquidity))
+        amount = max(amount1, amount2, amount3)
+        if amount < min_amount:
+            return result
+        amount = int(min(amount, get_max_amount(i, min_amount, enough_liquidity)))
+        maxfee = get_max_fee(plugin, amount)
+        plugin.log(f"Try to rebalance: {scid1} -> {scid2}; amount={amount:,} msat; maxfee={maxfee:,} msat")
+        try:
+            res = rebalance(plugin, outgoing_scid=scid1, incoming_scid=scid2, msatoshi=amount, maxfeepercent=0, retry_for=1200, exemptfee=maxfee)
+        except Exception:
+            failed_pairs.append(scid1 + ":" + scid2)
+            # rebalance failed, let's try with a smaller amount
+            while (get_max_amount(i, min_amount, enough_liquidity) >= amount and
+                   get_max_amount(i, min_amount, enough_liquidity) != get_max_amount(i + i, min_amount, enough_liquidity)):
+                i += 1
+            if amount > get_max_amount(i, min_amount, enough_liquidity):
+                continue
+            return result
+        plugin.log(f"Rebalance succeeded: {res}")
+        result["success"] = True
+        result["fee_spent"] += res["fee"]
+        # refresh channels
+        time.sleep(10)
+        ch1 = get_chan(plugin, scid1)
+        assert ch1 is not None
+        ch2 = get_chan(plugin, scid2)
+        assert ch2 is not None
+
+
+def maybe_rebalance_once(plugin: Plugin, failed_pairs: list):
+    channels = get_our_channels(plugin)
+    for ch1 in channels:
+        for ch2 in channels:
+            result = maybe_rebalance_pairs(plugin, ch1, ch2, failed_pairs)
+            if result["success"] == True:
+                return result
+    return {"success": False, "fee_spent": 0}
+
+
+def rebalanceall_thread(plugin: Plugin):
+    try:
+        channels = get_our_channels(plugin)
+        enough_liquidity = get_enough_liquidity_threshold(channels)
+        ideal_ratio = get_ideal_ratio(channels, enough_liquidity)
+        plugin.log(f"Automatic rebalance is running with enough liquidity threshold: {enough_liquidity:,} msat, "
+                   f"ideal liquidity ratio: {ideal_ratio * 100:.2f}%, "
+                   f"min rebalancable amount: {int(Millisatoshi(plugin.get_option('min-amount'))):,} msat, "
+                   f"feeratio: {plugin.get_option('feeratio')}")
+        plugin.options["enough-liquidity"]["value"] = enough_liquidity
+        plugin.options["ideal-ratio"]["value"] = ideal_ratio
+        failed_pairs = []
+        success = 0
+        fee_spent = 0
+        while True:
+            result = maybe_rebalance_once(plugin, failed_pairs)
+            if result["success"] == False:
+                break
+            success += 1
+            fee_spent += result["fee_spent"]
+            feeadjust_would_be_nice(plugin)
+        plugin.log(f"Automatic rebalance finished: {success} successful rebalance, {fee_spent:,} msat fee spent")
+    finally:
+        plugin.mutex.release()
+
+
+@plugin.method("rebalanceall")
+def rebalanceall(plugin: Plugin, min_amount: Millisatoshi = Millisatoshi("50000sat"), feeratio: float = 0.5):
+    """Rebalance all unbalanced channels if possible for a very low fee.
+    Default minimum rebalancable amount is 50000sat. Default feeratio = 0.5, half of our node's default fee.
+    To be economical, it tries to fix the liquidity cheaper than it can be ruined by transaction forwards.
+    May run for a long time (hours) in the background.
+    """
+    if not plugin.mutex.acquire(blocking = False):
+        return {"message" : "Rebalance is already running, this may take a while"}
+    try:
+        plugin.options["feeratio"]["value"] = float(feeratio)
+        plugin.options["min-amount"]["value"] = Millisatoshi(min_amount)
+        t = Thread(target = rebalanceall_thread, args = (plugin, ))
+        t.start()
+    except Exception as e:
+        plugin.mutex.release()
+        raise e
+    return {"message" : "Rebalance started"}
+
+
 @plugin.init()
 def init(options, configuration, plugin):
-    plugin.options['cltv-final']['value'] = plugin.rpc.listconfigs().get('cltv-final')
+    config = plugin.rpc.listconfigs()
+    plugin.options["cltv-final"]["value"] = config.get("cltv-final")
+    plugin.options["fee-base"]["value"] = config.get("fee-base")
+    plugin.options["fee-per-satoshi"]["value"] = config.get("fee-per-satoshi")
+    plugin.mutex = Lock()
     plugin.log("Plugin rebalance.py initialized")
 
 
-plugin.add_option('cltv-final', 10, 'Number of blocks for final CheckLockTimeVerify expiry')
+plugin.add_option("cltv-final", 10, "Number of blocks for final CheckLockTimeVerify expiry", "int")
+plugin.add_option("fee-base", 0, "The routing base fee in msat. Will be derived automatically via rpc.listconfigs()", "int")
+plugin.add_option("fee-per-satoshi", 0, "The routing fee ppm. Will be derived automatically via rpc.listconfigs()", "int")
+plugin.add_option("feeratio", "0.5", "Rebalance fee in the ratio of our node's default fee. Default 0.5 means it will use max half of our fee.", "string")
+plugin.add_option("enough-liquidity", 0, "Above this threshold (in msat), a channel's liquidity is big enough. Will be calculated.", "int")
+plugin.add_option("ideal-ratio", "0.5", "Ideal liquidity ratio for big channels. Will be calculated.", "string")
+plugin.add_option("min-amount", "50000sat", "The minimum rebalancable amount.", "string")
 plugin.run()


### PR DESCRIPTION
- rebalances liquidity between channels through circular payments
- automatically selects appropriate channels and executes rebalance
- uses economic fee by default: the rebalance transaction fees are less than the node's default fee, so it is cheaper to fix the liquidity than it can be ruined by transaction forwards
- runs async in the background, sometimes for a very long time (maybe hours)
- tries to rebalance small channels to a 50/50 liquidity ratio and stores remaining liquidity in big channels
- does nothing if there is no cheap enough circular route for rebalance