### PR TITLE
backup: Add the ability to compact the backups

### DIFF
--- a/backup/backup.py
+++ b/backup/backup.py
@@ -192,7 +192,8 @@ class FileBackend(Backend):
     def add_change(self, entry: Change) -> bool:
         typ = b'\x01' if entry.snapshot is None else b'\x02'
         if typ == b'\x01':
-            payload = b'\x00'.join([t.encode('UTF-8') for t in entry.transaction])
+            stmts = [t.encode('UTF-8') if isinstance(t, str) else t for t in entry.transaction]
+            payload = b'\x00'.join(stmts)
         elif typ == b'\x02':
             payload = entry.snapshot
 


### PR DESCRIPTION
Fundamentally backups using the `FileBackend` are just a snapshot of the
`sqlite3` database followed by incremental changes that are applied on
top of that snapshot. This means that backups will grow indefinitely
over time, and may cause some issues:

 - Long restore time: the more changes are appended to a backup the
   longer it takes to apply them on restore.
 - Large files: we had reports of users running on fat32, which fails
   spectacularly when the filesize exceeds 2GB

This PR implements compactions for the `FileBackend`, by performing
the following steps:

 - `lightning-cli backup-compact` initiates the compaction
 - The existing backup is taken, and restored up to the second to last
   change to a new database:
    - Extract snapshot
	- Apply incremental changes
 - A new snapshot is taken of the restored DB and a new backup is
   initiated with that snapshot.
 - The last missing change is appended to the new backup. This is
   necessary to enable `rewind` operations if the last change is not
   committed by c-lightning.
 - The old backup is atomically overwritten by the new one
 - The backup plugin is re-initialized with the new backup
 - Return the result of the compaction to the caller
 
Atomicity is achieved by putting the new backup in the same directory
as the original, maximizing the probability of it just being an atomic
`rename` from old to new.

Due to the offsets and version numbers having to match up precisely,
the code is a bit finicky, but we should be able to eventually
refactor the `restore` code and the `compact` code to reuse the same
logic.