### PR TITLE
chore: renames RPC feeadjusttoggle to feeadjust-toggle

### DIFF
--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -206,8 +206,8 @@ def feeadjust(plugin: Plugin):
     return msg
 
 
-@plugin.method("feeadjustertoggle")
-def feeadjustertoggle(plugin: Plugin, value: bool = None):
+@plugin.method("feeadjuster-toggle")
+def feeadjuster_toggle(plugin: Plugin, value: bool = None):
     """Activates/Deactivates automatic fee updates for forward events.
 
     The status will be set to value.

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -414,9 +414,9 @@ def maybe_rebalance_once(plugin: Plugin, failed_pairs: list):
 
 
 def feeadjuster_toggle(plugin: Plugin, new_value: bool):
-    commands = [c for c in plugin.rpc.help().get("help") if c["command"].split()[0] == "feeadjustertoggle"]
+    commands = [c for c in plugin.rpc.help().get("help") if c["command"].split()[0] == "feeadjuster-toggle"]
     if len(commands) == 1:
-        msg = plugin.rpc.feeadjustertoggle(new_value)
+        msg = plugin.rpc.feeadjuster_toggle(new_value)
         return msg["forward_event_subscription"]["previous"]
     else:
         return True


### PR DESCRIPTION
After small chat with cdecker, using dash/minus in RPC name is good and will be translated to underscore in pyln on the fly.