### PR TITLE
Avoid out of IndexError from `historian-stats`

### DIFF
--- a/historian/historian.py
+++ b/historian/historian.py
@@ -186,8 +186,8 @@ def stats(plugin):
         'channel_announcements': session.query(ChannelAnnouncement).count(),
         'channel_updates': session.query(ChannelUpdate).count(),
         'node_announcements': session.query(NodeAnnouncement).count(),
-        'latest_node_announcement': session.query(NodeAnnouncement).order_by(desc(NodeAnnouncement.timestamp)).limit(1)[0],
-        'latest_channel_update': session.query(ChannelUpdate).order_by(desc(ChannelUpdate.timestamp)).limit(1)[0],
+        'latest_node_announcement': session.query(NodeAnnouncement).order_by(desc(NodeAnnouncement.timestamp)).limit(1).first(),
+        'latest_channel_update': session.query(ChannelUpdate).order_by(desc(ChannelUpdate.timestamp)).limit(1).first(),
     }
 
 


### PR DESCRIPTION
Fixes a bug where `historian-stats` would give IndexError when no announcements or updates where recorded yet.