### PR TITLE
backup: fix deadlock by removing the sqlite3 check

### DIFF
--- a/backup/backup.py
+++ b/backup/backup.py
@@ -443,9 +443,12 @@ def on_init(options, **kwargs):
             level="warn"
         )
 
-    configs = plugin.rpc.listconfigs()
-    if not configs['wallet'].startswith('sqlite3'):
-        kill("The backup plugin only works with the sqlite3 database.")
+    # IMPORTANT NOTE
+    # Putting RPC stuff in init() like the following can cause deadlocks!
+    # See: https://github.com/lightningd/plugins/issues/209
+    #configs = plugin.rpc.listconfigs()
+    #if not configs['wallet'].startswith('sqlite3'):
+    #    kill("The backup plugin only works with the sqlite3 database.")
 
 
 def kill(message: str):


### PR DESCRIPTION
'fixes' https://github.com/lightningd/plugins/issues/209

I commented out that check and placed a NOTE that future developers
to see upfront putting in RPC stuff in init is potentially bad.