### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM elementsproject/lightningd
+
+ARG EXTRA_PLUGINS='--recurse-submodules=csvexportpays \
+--recurse-submodules=graphql \
+--recurse-submodules=jwt-factory \
+--recurse-submodules=python-teos \
+--recurse-submodules=trustedcoin \
+--recurse-submodules=webhook'
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential python3-wheel python3-dev python3-venv libleveldb-dev pkg-config libc-bin git libpq-dev postgresql
+
+COPY . /tmp/plugins
+RUN mkdir /tmp/oldplugins && mv /opt/lightningd/plugins/* /tmp/oldplugins/ && \
+    cd /opt/lightningd/plugins && \
+    git clone --depth 1 --shallow-submodules -j4 \
+        ${EXTRA_PLUGINS} \
+        file:///tmp/plugins . && \
+    pip3 install setuptools && \
+    find -name requirements.txt -exec pip3 install -r {} \; && \
+    mv /tmp/oldplugins/* /opt/lightningd/plugins/ && rmdir /tmp/oldplugins
+
+EXPOSE 9735 9835
+ENTRYPOINT  [ "/usr/bin/tini", "-g", "--", "./entrypoint.sh" ]


### PR DESCRIPTION
This adds an extended Dockerfile based on the official image, with common dependencies (as well as postgresql to enable out-of-box compatability for that, which lacks in the base file).

The build arg `PLUGINS` can be modified to select specific plugins.

Notably plugins that require compilation (e.g. sparko) are not built here. That can be resolved either by layering either image on the other or copy over files from https://github.com/fiatjaf/sparko/blob/master/Dockerfile - or ideally this Dockerfile itself can be improved by adding build args to optionally build them using additional stages

Plenty of things that can be improved here and use-cases that aren't catered for explicitly, but I'm figuring this is a decently sane base for anyone to extend their custom things on while making it smoother to tie things together for a base setup.