### PR TITLE
Fix missing parser error

### DIFF
--- a/historian/gossipd.py
+++ b/historian/gossipd.py
@@ -162,6 +162,7 @@ def parse(b):
         257: parse_node_announcement,
         258: parse_channel_update,
         3503: parse_ignore,
+        4103: parse_ignore,
     }
 
     if typ not in parsers:


### PR DESCRIPTION
Fixes an exception thrown for not having a parser for message type 4103. These messages are now just ignored (maybe should be handled somehow?)