### PR TITLE
Fix handling of ignored messages in historian.py

### DIFF
--- a/historian/historian.py
+++ b/historian/historian.py
@@ -161,10 +161,13 @@ class Flusher(Thread):
 
             elif isinstance(msg, gossipd.NodeAnnouncement):
                 cls = NodeAnnouncement
+                
+            else:
+                return;
 
             self.session.merge(cls.from_gossip(msg, raw))
         except Exception as e:
-            print("Exception parsing gossip message:", e)
+            logging.warn("Exception parsing gossip message:", e)
 
 
 @plugin.init()

--- a/historian/historian.py
+++ b/historian/historian.py
@@ -167,7 +167,7 @@ class Flusher(Thread):
 
             self.session.merge(cls.from_gossip(msg, raw))
         except Exception as e:
-            logging.warn("Exception parsing gossip message:", e)
+            logging.warn(f"Exception parsing gossip message: {e}")
 
 
 @plugin.init()


### PR DESCRIPTION
Fixes a bug where gossip messages that are ignored by the historian plugin will trigger an exception being printed.