### PR TITLE
backup: Add support for IPv6 addresses in socket backend

### DIFF
--- a/backup/remote.md
+++ b/backup/remote.md
@@ -15,7 +15,8 @@ The remote backup system consists of two parts:
 - A server daemon that receives changes from the backup backend and communicates with a local backup backend
   to store them. The server side does not need to be running c-lightning, nor have it installed.
 
-The backend URL format is `socket:<host>:<port>`. For example `socket:127.0.0.1:1234`.
+The backend URL format is `socket:<host>:<port>`. For example `socket:127.0.0.1:1234`. To supply a IPv6
+address use the bracketed syntax `socket:[::1]:1234`.
 
 To run the server against a local backend use `backup-cli server file://.../ 127.0.0.1:1234`.
 


### PR DESCRIPTION
Support the bracketed `socket:[::]:1234` syntax for IPv6 addresses.

Also, factor out the socket URI parsing to a function and add tests for it. 

As a forward compatibility measure, reject query strings (`?a=b`) because I intend to use these for parameters such as SOCKS5 proxy (for Tor) in a future patch.