### PR TITLE
backup: Improve logging configurability for socket server

### DIFF
--- a/backup/backup-cli
+++ b/backup/backup-cli
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from backends import get_backend
 from backend import Change
-from server import SocketServer
+from server import SocketServer, setup_server_logging
 
 import os
 import click
@@ -74,10 +74,15 @@ def restore(backend_url, restore_destination):
 @click.command()
 @click.argument("backend-url")
 @click.argument("addr")
-def server(backend_url, addr):
+@click.option('--log-mode', type=click.Choice(['plain', 'systemd'], case_sensitive=False), default='plain', help='Debug log mode, defaults to plain')
+@click.option('--log-level', type=click.Choice(['debug', 'info', 'notice', 'warning', 'error', 'critical'], case_sensitive=False), default='info', help='Debug log level, defaults to info')
+def server(backend_url, addr, log_mode, log_level):
     backend = get_backend(backend_url)
     addr, port = addr.split(':')
     port = int(port)
+
+    setup_server_logging(log_mode, log_level)
+
     server = SocketServer((addr, port), backend)
     server.run()
 


### PR DESCRIPTION
Add two optional arguments to `backup-cli server`:

- `--log-mode`: either `plain` (simply print the log message) or `systemd` (prefix log message with systemd log level, useful for running as a  a service)

- `--log-level`: minimum level for messages to be logged, from `DEBUG` to `CRITICAL`

Also, move some noisy messages to the debug level.

Example systemd service file (might make sense to add this to the documentation):
```
[Unit]
Description=C-lightning backup server
After=network.target
StartLimitIntervalSec=0

[Service]
Type=simple
Restart=always
RestartSec=1
User=<user>
ExecStart=<path>/plugins/backup/backup-cli server --log-level debug --log-mode systemd file://<backup> 127.0.0.1:8700

[Install]
WantedBy=multi-user.target
```