### PR TITLE
currencyrate: fix what happens when we get an error.

### DIFF
--- a/currencyrate/currencyrate.py
+++ b/currencyrate/currencyrate.py
@@ -68,7 +68,7 @@ def get_currencyrate(plugin, currency, urlformat, replymembers):
     # Workaround: retry up to 5 times with a delay
     currency_lc = currency.lower()
     url = urlformat.format(currency_lc=currency_lc, currency=currency)
-    r = requests_retry_session(retries=5, status_forcelist=(404)).get(url, proxies=plugin.proxies)
+    r = requests_retry_session(retries=5, status_forcelist=[404]).get(url, proxies=plugin.proxies)
 
     if r.status_code != 200:
         plugin.log(level='info', message='{}: bad response {}'.format(url, r.status_code))


### PR DESCRIPTION
root@ubuntu-s-4vcpu-8gb-nyc3-01:~# l2-cli currencyrates USD
{
   "code": -32600,
   "message": "Error while processing currencyrates: argument of type 'int' is not iterable",
   "traceback": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.8/dist-packages/pyln/client/plugin.py\", line 621, in _dispatch_request\n    result = self._exec_func(method.func, request)\n  File \"/usr/local/lib/python3.8/dist-packages/pyln/client/plugin.py\", line 603, in _exec_func\n    return func(*ba.args, **ba.kwargs)\n  File \"/root/plugins/currencyrate/currencyrate.py\", line 121, in currencyrates\n    return get_rates(plugin, currency.upper())\n  File \"/usr/local/lib/python3.8/dist-packages/cachetools/decorators.py\", line 22, in wrapper\n    v = func(*args, **kwargs)\n  File \"/root/plugins/currencyrate/currencyrate.py\", line 110, in get_rates\n    r = get_currencyrate(plugin, currency, s.urlformat, s.replymembers)\n  File \"/root/plugins/currencyrate/currencyrate.py\", line 71, in get_currencyrate\n    r = requests_retry_session(retries=5, status_forcelist=(404)).get(url, proxies=plugin.proxies)\n  File \"/usr/lib/python3/dist-packages/requests/sessions.py\", line 543, in get\n    return self.request('GET', url, **kwargs)\n  File \"/usr/lib/python3/dist-packages/requests/sessions.py\", line 530, in request\n    resp = self.send(prep, **send_kwargs)\n  File \"/usr/lib/python3/dist-packages/requests/sessions.py\", line 643, in send\n    r = adapter.send(request, **kwargs)\n  File \"/usr/lib/python3/dist-packages/requests/adapters.py\", line 439, in send\n    resp = conn.urlopen(\n  File \"/usr/lib/python3/dist-packages/urllib3/connectionpool.py\", line 803, in urlopen\n    if retries.is_retry(method, response.status, has_retry_after):\n  File \"/usr/lib/python3/dist-packages/urllib3/util/retry.py\", line 339, in is_retry\n    if self.status_forcelist and status_code in self.status_forcelist:\nTypeError: argument of type 'int' is not iterable\n"
}

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>