### PR TITLE
probe: Allow the caller to specify the amount to probe

### DIFF
--- a/probe/test_probe.py
+++ b/probe/test_probe.py
@@ -1,3 +1,4 @@
+import unittest
 import os
 from pyln.testing.fixtures import *  # noqa: F401,F403
 
@@ -14,3 +15,44 @@ def test_probe_starts(node_factory):
     # Then statically
     l1.daemon.opts["plugin"] = plugin_path
     l1.start()
+
+
+@unittest.skipIf(not DEVELOPER, "Gossip is slow")
+def test_probe(node_factory):
+    l1, l2, l3, l4 = node_factory.line_graph(
+        4,
+        opts=[
+            {'plugin': plugin_path},
+            {},
+            {},
+            {}
+        ],
+        wait_for_announce=True
+    )
+
+    res = l1.rpc.probe(l4.info['id'])
+    assert(res['destination'] == l4.info['id'])
+    assert(res['failcode'] == 16399)
+
+
+@unittest.skipIf(not DEVELOPER, "Gossip is slow")
+def test_route_unreachable(node_factory):
+    l1, l2, l3, l4 = node_factory.line_graph(
+        4,
+        opts=[
+            {'plugin': plugin_path},
+            {},
+            {},
+            {}
+        ],
+        wait_for_announce=True
+    )
+
+    l2.rpc.close(l3.info['id'])
+
+    res = l1.rpc.probe(l4.info['id'])
+    assert(res['destination'] == l4.info['id'])
+    assert(res['failcode'] == 16394)
+    route = res['route'].split(',')
+    assert(route.index(res['erring_channel']) == 1)
+


### PR DESCRIPTION
We used to only probe for a 10sat amount, which allows us to test
basic reachability, but it doesn't say much about whether we can
actually pay for something reasonable, so this fixes that.

This may require the following SQL statement to be applied to the
database if you are upgrading from a prior version:

```sql
ALTER TABLE probes ADD amount INTEGER;
```

This is not required if you start with a new database.