### PR TITLE
paytest: Fix crash reported by m-schmoock on direct payment

### DIFF
--- a/paytest/paytest.py
+++ b/paytest/paytest.py
@@ -246,7 +246,7 @@ def on_htlc_accepted(onion, htlc, request, plugin, *args, **kwargs):
         )
     )
     # If this is not a test payment, pass it on
-    if onion["short_channel_id"] != "1x1x1":
+    if 'short_channel_id' not in onion or onion["short_channel_id"] != "1x1x1":
         return request.set_result({"result": "continue"})
 
     # Decode the onion so we get the details the virtual recipient

--- a/paytest/paytest.py
+++ b/paytest/paytest.py
@@ -252,7 +252,10 @@ def on_htlc_accepted(onion, htlc, request, plugin, *args, **kwargs):
     # Decode the onion so we get the details the virtual recipient
     # would get.
     ro = RoutingOnion.from_hex(onion["next_onion"])
-    payload, next_onion = ro.unwrap(PRIVKEY, unhexlify(PAYMENT_HASH))
+    try:
+        payload, next_onion = ro.unwrap(PRIVKEY, unhexlify(PAYMENT_HASH))
+    except Exception:
+        return request.set_result({"result": "continue"})
 
     if next_onion is not None:
         # Whoops, apparently the virtual node isn't the last hop, fail

--- a/paytest/test_paytest.py
+++ b/paytest/test_paytest.py
@@ -57,7 +57,6 @@ def test_mpp_pay(node_factory):
     assert len(is16399) >= 1
 
 
-@pytest.mark.xfail(strict=True)
 def test_incoming_payment(node_factory):
     """Ensure that we don't fail if the payment is not a paytest.
     """


### PR DESCRIPTION
We crash the plugin accidentally if we're not handling a paytest but
rather a payment destined for us, due to us falsely assuming the
short-channel-id to be set in the onion

Reported-by: Michael Schmoock <@m-schmoock>