### PR TITLE
Rebalance improvements

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -197,8 +197,9 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
 
             try:
                 plugin.rpc.sendpay(route, payment_hash)
-                plugin.rpc.waitsendpay(payment_hash, retry_for + start_ts - int(time.time()))
-                return success_msg
+                running_for = int(time.time()) - start_ts
+                plugin.rpc.waitsendpay(payment_hash, max(retry_for - running_for, 0))
+                break
 
             except RpcError as e:
                 plugin.log("RpcError: " + str(e), 'debug')

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -280,11 +280,11 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
                 if erring_channel is not None and erring_direction is not None:
                     excludes.append(erring_channel + '/' + str(erring_direction))
                 # count and exclude nodes that produce a lot of errors
-                if erring_node:
+                if erring_node and plugin.erringnodes > 0:
                     if nodes.get(erring_node) is None:
                         nodes[erring_node] = 0
                     nodes[erring_node] += 1
-                    if nodes[erring_node] > 3:
+                    if nodes[erring_node] >= plugin.erringnodes:
                         excludes.append(erring_node)
 
     except Exception as e:
@@ -624,10 +624,13 @@ def init(options, configuration, plugin):
     plugin.mutex = Lock()
     plugin.maxhops = int(options.get("rebalance-maxhops"))
     plugin.msatfactor = float(options.get("rebalance-msatfactor"))
+    plugin.erringnodes = int(options.get("rebalance-erringnodes"))
+
     plugin.log(f"Plugin rebalance initialized with {plugin.fee_base} base / {plugin.fee_ppm} ppm fee  "
                f"cltv_final:{plugin.cltv_final}  "
                f"maxhops:{plugin.maxhops}  "
-               f"msatfactor:{plugin.msatfactor}")
+               f"msatfactor:{plugin.msatfactor} "
+               f"erringnodes:{plugin.erringnodes}")
 
 
 plugin.add_option(
@@ -646,4 +649,13 @@ plugin.add_option(
     "Note: This will decrease to 1 when no routes can be found.",
     "string"
 )
+
+plugin.add_option(
+    "rebalance-erringnodes",
+    "5",
+    "Exclude nodes from routing that raised N or more errors. "
+    "Note: Use 0 to disable.",
+    "string"
+)
+
 plugin.run()

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -173,7 +173,7 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
         excludes = [my_node_id]  # excude all own channels to prevent shortcuts
 
         while int(time.time()) - start_ts < retry_for and not plugin.rebalance_stop:
-            r = plugin.rpc.getroute(incoming_node_id, msatoshi, riskfactor=1, cltv=9, fromid=outgoing_node_id, exclude=excludes)
+            r = plugin.rpc.getroute(incoming_node_id, msatoshi, riskfactor=10, cltv=9, fromid=outgoing_node_id, exclude=excludes, maxhops=5)
             route_mid = r['route']
             route = [route_out] + route_mid + [route_in]
             setup_routing_fees(plugin, route, msatoshi)

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -209,14 +209,12 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
                 if e.method == "getroute" and e.error.get('code') == 205:
                     # reduce msatfactor to look for smaller channels now
                     msatfactor -= 1
-                    if msatfactor == 0:
+                    if msatfactor < 1:
                         # when we reached neutral msat factor:
                         # increase maxhops and restart with msatfactor
                         maxhops = maxhops + 1
                         msatfactor = plugin.msatfactor
-                        continue
-                    # we observed that we only have a ~3% success rate on routes that
-                    # are 8 hops or longer. Hence we cut at 6 (+2 in/out).
+                    # abort if we reached maxhop limit
                     if plugin.maxhops > 0 and maxhops > plugin.maxhops:
                         rpc_result = {'status': 'error', 'message': 'No suitable routes found'}
                         return cleanup(plugin, label, payload, rpc_result)

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -182,11 +182,11 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
     payment_hash = invoice['payment_hash']
 
     rpc_result = None
-    excludes = [my_node_id]  # excude all own channels to prevent shortcuts
-    nodes = {}               # here we store erring node counts
-    _maxhops = 1             # start with short routes and increase
-    _msatfactor = msatfactor # start with high msatoshi factor to reduce
-                             # WIRE_TEMPORARY failures because of imbalances
+    excludes = [my_node_id]   # excude all own channels to prevent shortcuts
+    nodes = {}                # here we store erring node counts
+    _maxhops = 1              # start with short routes and increase
+    _msatfactor = msatfactor  # start with high msatoshi factor to reduce
+                              # WIRE_TEMPORARY failures because of imbalances
 
     # 'disable' maxhops filter if set to <= 0
     # I know this is ugly, but we don't ruin the rest of the code this way
@@ -491,8 +491,8 @@ def maybe_rebalance_pairs(plugin: Plugin, ch1, ch2, failed_channels: list):
         start_ts = time.time()
         try:
             res = rebalance(plugin, outgoing_scid=scid1, incoming_scid=scid2,
-                    msatoshi=amount, retry_for=1200, maxfeepercent=0,
-                    exemptfee=maxfee, maxhops=6, msatfactor=1)
+                            msatoshi=amount, retry_for=1200, maxfeepercent=0,
+                            exemptfee=maxfee, maxhops=6, msatfactor=1)
             if not res.get('status') == 'complete':
                 raise Exception  # fall into exception handler below
         except Exception:

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -130,7 +130,7 @@ def calc_optimal_amount(out_ours, out_total, in_ours, in_total, payload):
 
 @plugin.method("rebalance")
 def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = None,
-              maxfeepercent: float = 0.5, retry_for: int = 60,
+              retry_for: int = 60, maxfeepercent: float = 0.5,
               exemptfee: Millisatoshi = Millisatoshi(5000),
               maxhops: int = None, msatfactor: float = None):
     """Rebalancing channel liquidity with circular payments.
@@ -139,8 +139,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
     """
     if msatoshi:
         msatoshi = Millisatoshi(msatoshi)
-    maxfeepercent = float(maxfeepercent)
     retry_for = int(retry_for)
+    maxfeepercent = float(maxfeepercent)
     if maxhops is None:
         maxhops = plugin.maxhops
     if msatfactor is None:
@@ -150,8 +150,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
         "outgoing_scid": outgoing_scid,
         "incoming_scid": incoming_scid,
         "msatoshi": msatoshi,
-        "maxfeepercent": maxfeepercent,
         "retry_for": retry_for,
+        "maxfeepercent": maxfeepercent,
         "exemptfee": exemptfee
     }
     my_node_id = plugin.rpc.getinfo().get('id')
@@ -491,7 +491,7 @@ def maybe_rebalance_pairs(plugin: Plugin, ch1, ch2, failed_channels: list):
         start_ts = time.time()
         try:
             res = rebalance(plugin, outgoing_scid=scid1, incoming_scid=scid2,
-                    msatoshi=amount, maxfeepercent=0, retry_for=1200,
+                    msatoshi=amount, retry_for=1200, maxfeepercent=0,
                     exemptfee=maxfee, maxhops=6, msatfactor=1)
             if not res.get('status') == 'complete':
                 raise Exception  # fall into exception handler below

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -155,8 +155,6 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
     get_channel(plugin, payload, incoming_node_id, incoming_scid, True)
     out_ours, out_total = amounts_from_scid(plugin, outgoing_scid)
     in_ours, in_total = amounts_from_scid(plugin, incoming_scid)
-    plugin.log("Outgoing node: %s, channel: %s" % (outgoing_node_id, outgoing_scid), 'debug')
-    plugin.log("Incoming node: %s, channel: %s" % (incoming_node_id, incoming_scid), 'debug')
 
     # If amount was not given, calculate a suitable 50/50 rebalance amount
     if msatoshi is None:
@@ -166,6 +164,8 @@ def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = Non
     # Check requested amounts are selected channels
     if msatoshi > out_ours or msatoshi > in_total - in_ours:
         raise RpcError("rebalance", payload, {'message': 'Channel capacities too low'})
+
+    plugin.log(f"starting rebalance out_scid:{outgoing_scid} in_scid:{incoming_scid} amount:{msatoshi}", 'debug')
 
     route_out = {'id': outgoing_node_id, 'channel': outgoing_scid, 'direction': int(not my_node_id < outgoing_node_id)}
     route_in = {'id': my_node_id, 'channel': incoming_scid, 'direction': int(not incoming_node_id < my_node_id)}

--- a/rebalance/test_rebalance.py
+++ b/rebalance/test_rebalance.py
@@ -55,7 +55,7 @@ def test_rebalance_manual(node_factory, bitcoind):
     # check we can do an auto amount rebalance
     result = l1.rpc.rebalance(scid12, scid31)
     print(result)
-    assert result['status'] == 'settled'
+    assert result['status'] == 'complete'
     assert result['outgoing_scid'] == scid12
     assert result['incoming_scid'] == scid31
     assert result['hops'] == 3
@@ -72,7 +72,7 @@ def test_rebalance_manual(node_factory, bitcoind):
 
     # check we can do a manual amount rebalance in the other direction
     result = l1.rpc.rebalance(scid31, scid12, '250000000msat')
-    assert result['status'] == 'settled'
+    assert result['status'] == 'complete'
     assert result['outgoing_scid'] == scid31
     assert result['incoming_scid'] == scid12
     assert result['hops'] == 3


### PR DESCRIPTION
- this will fix and cleanup some things
- adds a feature where the plugin tries routes first that are more likely to be successful while brute forcing all possible routes later on. Meaning it will try shorter routes first, then a longer routes while simultaneously setting a higher requested capacity to `getroute` method and finally just trying all routes we can get.
- exclude nodes for future getroute requests that produce 4 or more `erring_node` errors (regardless the cause).