### PR TITLE
feeadjuster: fee strategy per channel

### DIFF
--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -147,14 +147,8 @@ def maybe_adjust_fees(plugin: Plugin, scids: list):
 
 def get_chan(plugin: Plugin, scid: str):
     for peer in plugin.peers:
-        if len(peer["channels"]) == 0:
-            continue
-        # We might have multiple channel entries ! Eg if one was just closed
-        # and reopened.
         for chan in peer["channels"]:
-            if "short_channel_id" not in chan:
-                continue
-            if chan["short_channel_id"] == scid:
+            if chan.get("short_channel_id") == scid:
                 return chan
 
 


### PR DESCRIPTION
This will cleanup some code and adds a configurable per channel fee strategy instead of always using global config or defaults. 

The new default strategy selects the median fees from the other peers of a peer.
The rational behind is that our node somehow competes towards that target.
The idea was raised by @ZmnSCPxj a while ago on IRC.

Using these median fees as base values for further calculation also feedbacks and reflects the current network state at that local area when/if the the local peers also use some dynamic methods.