### PR TITLE
rebalance: fix example usage in readme

### DIFF
--- a/rebalance/README.md
+++ b/rebalance/README.md
@@ -50,9 +50,12 @@ This process may take a while. Automatic rebalance can run for hours in the back
 You can use the `lightning-cli` to rebalance channels like this:
 
 ```
-lightning-cli rebalance outgoing_scid incoming_scid [msatoshi] [maxfeepercent] [retry_for] [exemptfee] [getroute_method]
+lightning-cli rebalance outgoing_scid incoming_scid [msatoshi] [retry_for] [maxfeepercent] [exemptfee] [getroute_method]
 ```
-
+def rebalance(plugin, outgoing_scid, incoming_scid, msatoshi: Millisatoshi = None,
+              retry_for: int = 60, maxfeepercent: float = 0.5,
+              exemptfee: Millisatoshi = Millisatoshi(5000),
+              getroute_method=None):
 If you want to skip/default certain optional parameters but use others, you can
 use always the `lightning-cli -k` (key=value) syntax like this:
 
@@ -68,10 +71,10 @@ lightning-cli rebalance -k outgoing_scid=1514942x51x0 incoming_scid=1515133x10x0
   transferred. If the parameter is left out, the plugin will calucate an amount
   that will balance the channels 50%/50%. The parameter can also be given in
   other denominations by appending i.e. '1000000sat', '0.01btc' or '10mbtc'.
-- OPTIONAL: `maxfeepercent` is a perecentage limit of the money to be paid in
-  fees and defaults to 0.5.
 - OPTIONAL: `retry_for` defines the number of seconds the plugin will retry to
   find a suitable route. Default: 60 seconds.
+- OPTIONAL: `maxfeepercent` is a perecentage limit of the money to be paid in
+  fees and defaults to 0.5.
 - OPTIONAL: The `exemptfee` option can be used for tiny payments which would be
   dominated by the fee leveraged by forwarding nodes. Setting `exemptfee`
   allows the `maxfeepercent` check to be skipped on fees that are smaller than


### PR DESCRIPTION
The parameters were in incorrect order, causing an error when user doesn't use with `-k`