### PR TITLE
exposed a method to cancel all outstanding test plugins

### DIFF
--- a/paytest/paytest.py
+++ b/paytest/paytest.py
@@ -240,10 +240,10 @@ def timeout(plugin, secret):
     del plugin.pending[secret]
         
         
-@plugin.method("timeoutallpendingtestpays")
-def timeoutallpendingtestpays(plugin, **kwargs):
+@plugin.method("rejectpaytests")
+def rejectpaytests(plugin, **kwargs):
     for secret in plugin.pending.keys():
-        timout(plugin,secret)
+        timeout(plugin,secret)
 
 @plugin.async_hook("htlc_accepted")
 def on_htlc_accepted(onion, htlc, request, plugin, *args, **kwargs):

--- a/paytest/paytest.py
+++ b/paytest/paytest.py
@@ -304,7 +304,7 @@ def on_htlc_accepted(onion, htlc, request, plugin, *args, **kwargs):
 
     parts = plugin.pending[ps]
     received = sum([p[2] for p in parts])
-    print("Received {:12} = {:4.2f}% with a total received of  {}/{} = {:4.2f}% with {} parts".format(int(Millisatoshi(onion["forward_amount"])),100*float(Millisatoshi(onion["forward_amount"]))/total,received, total,float(received)*100/total, len(parts)))
+    print("Received {:12} = {:4.2f}% with a total received of  {}/{} = {:4.2f}% with {} parts".format(int(Millisatoshi(onion["forward_amount"])),100.*int(Millisatoshi(onion["forward_amount"]))/total,received, total,float(received)*100/total, len(parts)))
 
     if received != total:
         return

--- a/paytest/paytest.py
+++ b/paytest/paytest.py
@@ -237,6 +237,13 @@ def timeout(plugin, secret):
     for p in parts:
         p[0].set_result({"result": "fail", "failure_onion": wrap_error(p[4], b"0017")})
 
+    del plugin.pending[secret]
+        
+        
+@plugin.method("timeoutallpendingtestpays")
+def timeoutallpendingtestpays(plugin, **kwargs):
+    for secret in plugin.pending.keys():
+        timout(plugin,secret)
 
 @plugin.async_hook("htlc_accepted")
 def on_htlc_accepted(onion, htlc, request, plugin, *args, **kwargs):

--- a/paytest/paytest.py
+++ b/paytest/paytest.py
@@ -242,7 +242,8 @@ def timeout(plugin, secret):
         
 @plugin.method("rejectpaytests")
 def rejectpaytests(plugin, **kwargs):
-    for secret in plugin.pending.keys():
+    secrets = list(plugin.pending.keys())
+    for secret in secrets:
         timeout(plugin,secret)
 
 @plugin.async_hook("htlc_accepted")
@@ -303,7 +304,7 @@ def on_htlc_accepted(onion, htlc, request, plugin, *args, **kwargs):
 
     parts = plugin.pending[ps]
     received = sum([p[2] for p in parts])
-    print("Received {}/{} with {} parts".format(received, total, len(parts)))
+    print("Received {:12} = {:4.2f}% with a total received of  {}/{} = {:4.2f}% with {} parts".format(int(Millisatoshi(onion["forward_amount"])),100*float(Millisatoshi(onion["forward_amount"]))/total,received, total,float(received)*100/total, len(parts)))
 
     if received != total:
         return


### PR DESCRIPTION
especially uncertain about line 240
because I don't know what actually happens on a protocol level if one tries to cancel an htlc that has already been canceled. would be bad if the channel gets failed. it wasn't clearly to me specified at: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#removing-an-htlc-update_fulfill_htlc-update_fail_htlc-and-update_fail_malformed_htlc

if that was a problem anyway we would still have race condition problems if the call comes roughly at the same time when the timeout timer triggers anyway