### PR TITLE
add fee percent that was taken in a successful rebalance

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -426,6 +426,7 @@ def rebalance(
                 "sent": msatoshi + fees,
                 "received": msatoshi,
                 "fee": fees,
+                "fee_percentage": f"{fees/msatoshi*100:.3}%",
                 "hops": len(route),
                 "outgoing_scid": outgoing_scid,
                 "incoming_scid": incoming_scid,


### PR DESCRIPTION
I think it is nice to know what was the fee percentage that was used in the re-balance, 
e.g. 
Instead of this:
fee": "59846msat",

It will output:
fee": "59846msat (0.114%)",