### PR TITLE
autopilot.py: Moved network initialization to new function to fix issues with timeout

### DIFF
--- a/autopilot/autopilot.py
+++ b/autopilot/autopilot.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-from bech32 import bech32_decode, CHARSET, convertbits
+from bech32 import bech32_decode, convertbits
 from lib_autopilot import Autopilot, Strategy
-from pyln.client import LightningRpc, Plugin, RpcError
+from pyln.client import Plugin, RpcError
 import random
 import threading
 import math
@@ -92,7 +92,7 @@ class CLightning_autopilot(Autopilot):
             print("Attempt RPC-call to download channels from the lightning network")
             channels = self.__rpc_interface.listchannels()["channels"]
             print("Number of retrieved channels: {}".format(len(channels)))
-        except ValueError as e:
+        except ValueError:
             print("Channel list could not be retrieved from the peers of the lightning network")
             return False
 
@@ -138,6 +138,12 @@ def init(configuration, options, plugin):
 
 @plugin.method('autopilot-run-once')
 def run_once(plugin, dryrun=False):
+    """
+    Run the autopilot manually one time.
+
+    The argument 'dryrun' can be set to True in order to just output what would
+    be done without actually opening any channels.
+    """
     # Let's start by inspecting the current state of the node
     funds = plugin.rpc.listfunds()
     awaiting_lockin_funds = sum([o['channel_sat'] for o in funds['channels'] if o['state'] == 'CHANNELD_AWAITING_LOCKIN'])

--- a/autopilot/autopilot.py
+++ b/autopilot/autopilot.py
@@ -11,6 +11,9 @@ import dns.resolver
 import time
 
 
+plugin = Plugin()
+
+
 class CLightning_autopilot(Autopilot):
 
     def __init__(self, rpc):
@@ -113,13 +116,6 @@ class CLightning_autopilot(Autopilot):
                     self.__rpc_interface.fundchannel(nodeid, satoshis, None, True, 0)
             except ValueError as e:
                 print("Could not open a channel to {} with capacity of {}. Error: {}".format(nodeid, satoshis, str(e)))
-
-
-try:
-    # C-lightning v0.7.2
-    plugin = Plugin(dynamic=False)
-except:
-    plugin = Plugin()
 
 
 @plugin.init()

--- a/autopilot/requirements.txt
+++ b/autopilot/requirements.txt
@@ -1,4 +1,4 @@
 dnspython>=1.16.0
-networkx==2.3
+networkx>=2.4
 numpy>=1.16
 pyln-client>=0.7.3

--- a/autopilot/test_autopilot.py
+++ b/autopilot/test_autopilot.py
@@ -1,0 +1,23 @@
+import os
+from pyln.testing.fixtures import *  # noqa: F401,F403
+
+plugin_path = os.path.join(os.path.dirname(__file__), "autopilot.py")
+plugin_opt = {'plugin': plugin_path}
+
+
+def test_starts(node_factory):
+    l1 = node_factory.get_node()
+    # Test dynamically
+    l1.rpc.plugin_start(plugin_path)
+    l1.rpc.plugin_stop(plugin_path)
+    l1.rpc.plugin_start(plugin_path)
+    l1.stop()
+    # Then statically
+    l1.daemon.opts["plugin"] = plugin_path
+    l1.start()
+
+
+def test_main(node_factory):
+    l1, l2 = node_factory.line_graph(2, wait_for_announce=True, opts=plugin_opt)
+    # just call main function
+    assert l1.rpc.autopilot_run_once()


### PR DESCRIPTION
Initialization for the autopilot plugin would time out due to how long it would take to execute, and lightningd would kill the plugin before finishing. This commit moves the graph calculation routine out of the initialization function to execute after the plugin was initialized. Initialization only reads in options passed from config file or on command line when lightningd was run.