### PR TITLE
WIP backup: optimize restore and backup-compact

### DIFF
--- a/backup/filebackend.py
+++ b/backup/filebackend.py
@@ -153,6 +153,7 @@ class FileBackend(Backend):
 
             if change.transaction is not None:
                 self._restore_transaction(change.transaction)
+        self.db.commit()
 
         # If this assertion fails we are in a degenerate state: we
         # have less than two changes in the backup (starting


### PR DESCRIPTION
Since I run the [clboss](https://github.com/ZmnSCPxj/clboss) plugin on CL, my `backup` grew to 7GB in a few weeks and calling `backup-compact` takes ages, blocks CL and shows no progress bar. The `bacup-cli restore` command is similarly slow (just 10 it/s). This is problematic because you can run out of disk space on the (backup) backend and also restore should not take days.

This PR wants to fix that:

- [x] optimize `compact` and `restore` by committing to db only once at the end, should be ok as no concurrent use of the db during compact or restore (now >1000 it/s !).

Other ideas:
- [ ] add `auto-compacting` option: when backup grows above certain size, call `backup-compact` (maybe in separate threat or when CL is not busy?).
- [x] the `backup-cli restore` progress bar is not working because `tqdm` cannot get length of the iterator [here](https://github.com/lightningd/plugins/blob/1f6f701bf1e60882b8fa61cb735e7033c8c29e3c/backup/backend.py#L121) (I think).