### PR TITLE
datastore: Skip the migration test when we have built-in datastore

### DIFF
--- a/datastore/test_datastore.py
+++ b/datastore/test_datastore.py
@@ -20,9 +20,9 @@ if not hasattr(LightningD, 'version'):
 
         cmd = ["lightningd", "--version"]
         vstr = subprocess.check_output(cmd).decode('ASCII')
-        logging.info(vstr)
+        print("XXX", vstr)
         tpl = re.match(vre, vstr).groups()
-        logging.info(tpl)
+        print("XXX", tpl)
         if len(tpl) > 3:
             return (int(tpl[0]), int(tpl[1]), int(tpl[2]), int(tpl[4]), tpl[6])
         else:

--- a/datastore/test_datastore.py
+++ b/datastore/test_datastore.py
@@ -20,8 +20,9 @@ if not hasattr(LightningD, 'version'):
 
         cmd = ["lightningd", "--version"]
         vstr = subprocess.check_output(cmd).decode('ASCII')
+        logging.info(vstr)
         tpl = re.match(vre, vstr).groups()
-
+        logging.info(tpl)
         if len(tpl) > 3:
             return (int(tpl[0]), int(tpl[1]), int(tpl[2]), int(tpl[4]), tpl[6])
         else:


### PR DESCRIPTION
The datastore tests were broken if the c-lightning built-in commands were available, which they now are.