### PR TITLE
backup: async backup-compact

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -20,7 +20,7 @@ pip3 install --user -r requirements.txt
 ## Setup
 
 Before the backup plugin can be used it has to be initialized once. The following
-command will create /mnt/external/location/file.sql as backup file and reference it 
+command will create /mnt/external/location/file.bkp as backup file and reference it
 in `backup.lock` in the lightning directory that stores the internal state, and 
 which makes sure no two instances are using the same backup. (Make sure to stop 
 your Lightning node before running this command)
@@ -36,7 +36,8 @@ Notes:
  - You should use some non-local SSH or NFS mount as destination,
    otherwise any failure of the disk may result in both the original
    as well as the backup being corrupted.
- - Currently only the `file:///` URL scheme is supported.
+ - Currently `file:///` and `socket:` URL schemes are supported. For using the
+   `socket:` URL scheme see: https://github.com/lightningd/plugins/blob/master/backup/remote.md
 
 ## IMPORTANT note about hsm_secret
 
@@ -69,8 +70,10 @@ restore the backup. This can be done through the plugin command `backup-compact`
 lightning-cli backup-compact
 ```
 
-Be aware that this can take a long time depending on the size of the backup
-and I/O speeds, during which the daemon will not be reachable.
+This command will start compaction in the background and returns immediately: {"result": "compaction started"}
+or {"result": "compaction still in progress"} if compaction is still running.
+If there is nothing to compact (version_count=2), the command will return: {'backupsize': <size_in_bytes>, 'version_count': 2}}
+It can be called again to reduce the backup size to its minimum size (version_count=2).
 
 ## Restoring a backup
 

--- a/backup/backend.py
+++ b/backup/backend.py
@@ -24,9 +24,13 @@ class Backend(object):
          - backend.version: the last data version we wrote to the backend
          - backend.prev_version: the previous data version in case we need to
            roll back the last one
+
+        Optional:
+         - version_count: number of changes added (snapshot + txn's) since init or compact
         """
         self.version = None
         self.prev_version = None
+        self.version_count = None
         raise NotImplementedError
 
     def add_change(self, change: Change) -> bool:

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -87,20 +87,10 @@ def compact(plugin, request, **kwargs):
     else:
         request.set_result(r) # plugin requires for immediate return
 
-@plugin.init()
-def on_init(options, **kwargs):
-    dest = options.get('backup-destination', 'null')
-    if dest != 'null':
-        plugin.log(
-            "The `--backup-destination` option is deprecated and will be "
-            "removed in future versions of the backup plugin. Please remove "
-            "it from your configuration. The destination is now determined by "
-            "the `backup.lock` file in the lightning directory",
-            level="warn"
-        )
 
     # IMPORTANT NOTE
-    # Putting RPC stuff in init() like the following can cause deadlocks!
+    # Don't make RPC calls (or any other) that trigger the db_write hook, we
+    # would deadlock as we cannot handle the hook simultaneous in a single threat.
     # See: https://github.com/lightningd/plugins/issues/209
     #configs = plugin.rpc.listconfigs()
     #if not configs['wallet'].startswith('sqlite3'):
@@ -149,12 +139,6 @@ def kill(message: str):
     # Sleep forever, just in case the master doesn't die on us...
     while True:
         time.sleep(30)
-
-
-plugin.add_option(
-    'backup-destination', None,
-    'UNUSED. Kept for backward compatibility only. Please update your configuration to remove this option.'
-)
 
 
 if __name__ == "__main__":

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -34,6 +34,9 @@ def check_first_write(plugin, data_version):
        c-lightning was running without the plugin at some point -> crash!
      - c-lighning is more than 1 write behind: c-lightning had a lobotomy, or
        was restored from an old backup -> crash!
+
+    Note that `data_version` belongs to the not-yet-committed transaction and is
+    one ahead of the version committed-to in c-lightning's database.
     """
     backend = plugin.backend
 

--- a/backup/contrib/init/lightningd_backup-compact.service
+++ b/backup/contrib/init/lightningd_backup-compact.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Call backup-compact for C-Lightning daemon, running with backup plugin
+Requires=lightningd.service
+After=lightningd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/lightning-cli --conf /etc/lightningd/lightningd.conf backup-compact
+
+User=bitcoin
+Group=bitcoin

--- a/backup/contrib/init/lightningd_backup-compact.timer
+++ b/backup/contrib/init/lightningd_backup-compact.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Weekly backup-compact for C-Lightning daemon
+
+[Timer]
+OnCalendar=weekly
+
+[Install]
+WantedBy=timers.target

--- a/backup/filebackend.py
+++ b/backup/filebackend.py
@@ -102,7 +102,8 @@ class FileBackend(Backend):
         return True
 
     def stream_changes(self, stop_version=None, offset=None) -> Iterator[Change]:
-        if not stop_version and self.read_metadata():
+        if stop_version is None:
+            self.read_metadata()
             stop_version = self.version
 
         offset = 512 if offset is None else offset
@@ -187,11 +188,11 @@ class FileBackend(Backend):
             if self.stop_compact:
                 return clone.cleanup()
 
-            if change.version == stop_ver:
-                break
-
             if change.snapshot is not None:
                 self._restore_snapshot(change.snapshot, snapshotpath)
+
+            if change.version == stop_ver:
+                break
 
             if change.transaction is not None:
                 self._restore_transaction(change.transaction)

--- a/backup/filebackend.py
+++ b/backup/filebackend.py
@@ -3,8 +3,10 @@ import shutil
 import tempfile
 from typing import Iterator
 from urllib.parse import urlparse
+import threading
 
 from backend import Backend, Change
+
 
 class FileBackend(Backend):
     def __init__(self, destination: str, create: bool):
@@ -14,9 +16,13 @@ class FileBackend(Backend):
         self.offsets = [0, 0]
         self.version_count = 0
         self.url = urlparse(self.destination)
+        self.lock = threading.Lock()
+        self.t = threading.Thread()
+        self.stop_compact = False
 
         if os.path.exists(self.url.path) and create:
             raise ValueError("Attempted to create a FileBackend, but file {} already exists.".format(self.url.path))
+
         if not os.path.exists(self.url.path) and not create:
             raise ValueError("Attempted to open a FileBackend but file doesn't already exists, use `backup-cli init` to initialize it first.")
         if create:
@@ -41,7 +47,6 @@ class FileBackend(Backend):
         with open(self.url.path, mode) as f:
             f.seek(0)
             f.write(blob)
-            f.flush()
 
     def read_metadata(self):
         with open(self.url.path, 'rb') as f:
@@ -68,22 +73,23 @@ class FileBackend(Backend):
 
         length = struct.pack("!I", len(payload))
         version = struct.pack("!I", entry.version)
-        with open(self.url.path, 'ab') as f:
-            f.seek(self.offsets[0])
-            f.write(length)
-            f.write(version)
-            f.write(typ)
-            f.write(payload)
-            self.prev_version, self.offsets[1] = self.version, self.offsets[0]
-            self.version = entry.version
-            self.offsets[0] += 9 + len(payload)
-            self.version_count += 1
-        self.write_metadata()
+        with self.lock: # _compact_async threat has concurrent access
+            with open(self.url.path, 'ab') as f:
+                f.seek(self.offsets[0])
+                f.write(length)
+                f.write(version)
+                f.write(typ)
+                f.write(payload)
+                self.prev_version, self.offsets[1] = self.version, self.offsets[0]
+                self.version = entry.version
+                self.offsets[0] += 9 + len(payload)
+                self.version_count += 1
+            self.write_metadata()
 
         return True
 
     def rewind(self):
-        # After rewinding we set offsets[0] and prev_version to 0 (best effort
+        # After rewinding we set offsets[1] and prev_version to 0 (best effort
         # result). If either of these are set to 0 we have two consecutive
         # rewinds which cannot be safely done (we'd be rewinding more than the
         # one in-flight transaction).
@@ -95,13 +101,16 @@ class FileBackend(Backend):
         self.prev_version, self.offsets[1] = 0, 0
         return True
 
-    def stream_changes(self) -> Iterator[Change]:
-        self.read_metadata()
+    def stream_changes(self, stop_version=None, offset=None) -> Iterator[Change]:
+        if not stop_version and self.read_metadata():
+            stop_version = self.version
+
+        offset = 512 if offset is None else offset
         version = -1
         with open(self.url.path, 'rb') as f:
             # Skip the header
-            f.seek(512)
-            while version < self.version:
+            f.seek(offset)
+            while version < stop_version:
                 length, version, typ = struct.unpack("!IIb", f.read(9))
                 payload = f.read(length)
                 if typ == 1:
@@ -115,37 +124,69 @@ class FileBackend(Backend):
                 else:
                     raise ValueError("Unknown FileBackend entry type {}".format(typ))
 
-            if version != self.version:
-                raise ValueError("Versions do not match up: restored version {}, backend version {}".format(version, self.version))
-            assert(version == self.version)
+            if version != stop_version:
+                raise ValueError("Versions do not match up: restored version {}, backend version {}".format(version, stop_version))
+
+
+    def stats(self):
+        return {'backupsize': os.stat(self.url.path).st_size,
+                'version_count': self.version_count}
+
 
     def compact(self):
-        stop = self.version  # Stop one version short of the head when compacting
-        tmp = tempfile.TemporaryDirectory()
-        backupdir, clonename = os.path.split(self.url.path)
+        # return something JSON serializable socketbackend (server) can pass
+        try:
+            if self.t.is_alive():
+                return {"result": "compaction still in progress"}
+            elif self.version_count == 2:
+                return {"result": self.stats()}
 
-        # Path of the backup clone that we're trying to build up. We
-        # are trying to put this right next to the original backup, to
-        # maximize the chances of both being on the same FS, which
-        # makes the move below atomic.
-        clonepath = os.path.join(backupdir, clonename + ".compacting")
+            # Path of the backup clone that we're trying to build up. We
+            # are trying to put this right next to the original backup, to
+            # maximize the chances of both being on the same FS, which
+            # makes the move below atomic.
+            # FIXME: Use urllib.parse to compose clone_dest?
+            clone_dest = self.destination + ".compacting"
+            clone = FileBackend(clone_dest, create=True)
+
+            self.t = threading.Thread(name='_compact_async', target=self._compact_async, args=(clone,))
+            self.t.start()
+            return {"result": "compaction started"}
+        except Exception as e:
+            logging.error(e) # handled exceptions are not logged
+            return {"error": str(e)}
+
+
+    def _compact_async(self, clone):
+        """
+        This method is thread safe but assumes other threads don't call `rewind`, which
+        seems fair as normally rewind only happens on first write at startup.
+        It blocks `add_change` briefly to read metadata, but later potentially
+        longer when catching-up with changes (db writes) that happened while compacting.
+        """
+        stats = {}
+        with self.lock: # freeze our view of latest backup state
+            self.read_metadata()
+            stop = self.version
+            stop_offset = self.offsets[1] # keep for catch-up later
+            stats['before'] = self.stats()
+
+        tmp = tempfile.TemporaryDirectory()
 
         # Location we extract the snapshot to and then apply
         # incremental changes.
         snapshotpath = os.path.join(tmp.name, "lightningd.sqlite3")
 
-        stats = {
-            'before': {
-                'backupsize': os.stat(self.url.path).st_size,
-                'version_count': self.version_count,
-            },
-        }
-
-        print("Starting compaction: stats={}".format(stats))
+        logging.info("Starting compaction: stats={}".format(stats))
         self.db = self._db_open(snapshotpath)
 
-        for change in self.stream_changes():
-            if change.version == stop:
+        # Remember `change`, it's the rewindable change we need to
+        # stash on top of the new snapshot.
+        for change in self.stream_changes(stop_version=stop):
+            if self.stop_compact:
+                return clone.cleanup()
+
+            if change.version == stop: # our snapshot will include up-to `stop` version - 1
                 break
 
             if change.snapshot is not None:
@@ -161,22 +202,18 @@ class FileBackend(Backend):
         # almost empty backup is not useful.
         assert change is not None
 
-        # Remember `change`, it's the rewindable change we need to
-        # stash on top of the new snapshot.
-        clone = FileBackend(clonepath, create=True)
-
         # We are about to add the snapshot n-1 on top of n-2 (init),
         # followed by the last change for n on top of
         # n-1. prev_version trails that by one.
-        clone.version = change.version - 2
+        clone.version = change.version - 2  # n-2
         clone.write_metadata()
 
         snapshot = Change(
-            version=change.version - 1,
+            version=change.version - 1,     # n-1
             snapshot=open(snapshotpath, 'rb').read(),
             transaction=None
         )
-        print("Adding initial snapshot with {} bytes for version {}".format(
+        logging.debug("Adding initial snapshot with {} bytes for version {}".format(
             len(snapshot.snapshot),
             snapshot.version
         ))
@@ -184,24 +221,50 @@ class FileBackend(Backend):
 
         assert clone.version == change.version - 1
         assert clone.prev_version == change.version - 2
-        print("Adding transaction for version {}".format(change.version))
-        clone.add_change(change)
+        logging.debug("Adding transaction for version {}".format(change.version))
+        clone.add_change(change)            # n
 
-        assert self.version == clone.version
-        assert self.prev_version == clone.prev_version
+        assert self.version >= clone.version # db_write's in other thread can only _add_
+        assert self.prev_version >= clone.prev_version
+        assert clone.version == stop
 
-        stats['after'] = {
-            'version_count': clone.version_count,
-            'backupsize': os.stat(clonepath).st_size,
-        }
+        # Refresh view of latest state so our clone can catch-up, then atomically
+        # move clone-->self, all while blocking on_db_write
+        # FIXME: depending on the backlog, catch-up (blocking c-lightning) can still
+        # take long, the critical section can probably be reduced.
+        with self.lock:
+            log = []
+            # fast-forward to where we left cloning and add versions we missed while compacting
+            for change in self.stream_changes(offset=stop_offset):
+                if self.stop_compact:
+                    return clone.cleanup()
 
-        print("Compacted {} changes, saving {} bytes, swapping backups".format(
-            stats['before']['version_count'] - stats['after']['version_count'],
-            stats['before']['backupsize'] - stats['after']['backupsize'],
-        ))
-        shutil.move(clonepath, self.url.path)
+                if change.version == stop: # clone already has it, skip
+                    continue
+                clone.add_change(change) # up-to and _including_ latest version
+                log.append(change.version)
 
-        # Re-initialize ourselves so we have the correct metadata
-        self.read_metadata()
+            if len(log):
+                logging.debug("Added transaction versions {} to {} that happened while compacting".format(log[0], log[-1]))
 
-        return stats
+            stats['after'] = clone.stats()
+            logging.info("Compaction completed: stats={}".format(stats))
+
+            assert clone.version == self.version
+            assert clone.prev_version == self.prev_version
+            logging.debug("swapping backups")
+            shutil.move(clone.url.path, self.url.path)
+
+            # Re-initialize ourselves so we have the correct metadata
+            self.read_metadata()
+
+
+    def cleanup(self):
+        os.remove(self.url.path)
+        logging.debug("compaction aborted")
+
+
+    def shutdown(self):
+        if self.t.is_alive():
+            self.stop_compact = True
+            self.t.join()

--- a/backup/requirements-dev.txt
+++ b/backup/requirements-dev.txt
@@ -1,1 +1,1 @@
-pyln-testing ~= 0.9.2
+pyln-testing ~= 0.10.1

--- a/backup/requirements.txt
+++ b/backup/requirements.txt
@@ -2,5 +2,5 @@ Click==7.0
 flaky>=3.6.1
 tqdm>=4.45
 psutil>=5
-pyln-client ~= 0.9.2
+pyln-client ~= 0.10.1
 packaging>=19.0

--- a/backup/requirements.txt
+++ b/backup/requirements.txt
@@ -3,3 +3,4 @@ flaky>=3.6.1
 tqdm>=4.45
 psutil>=5
 pyln-client ~= 0.9.2
+packaging>=19.0

--- a/backup/test_backup.py
+++ b/backup/test_backup.py
@@ -249,23 +249,6 @@ def test_restore_dir(node_factory, directory):
     subprocess.check_call([cli_path, "restore", bdest, bpath])
 
 
-def test_warning(directory, node_factory):
-    bpath = os.path.join(directory, 'lightning-1', 'regtest')
-    bdest = 'file://' + os.path.join(bpath, 'backup.dbak')
-    os.makedirs(bpath)
-    subprocess.check_call([cli_path, "init", "--lightning-dir", bpath, bdest])
-    opts = {
-        'plugin': plugin_path,
-        'allow-deprecated-apis': deprecated_apis,
-        'backup-destination': 'somewhere/over/the/rainbox',
-    }
-    l1 = node_factory.get_node(options=opts, cleandir=False)
-    l1.stop()
-
-    assert(l1.daemon.is_in_log(
-        r'The `--backup-destination` option is deprecated and will be removed in future versions of the backup plugin.'
-    ))
-
 class DummyBackend(Backend):
     def __init__(self):
         pass
@@ -314,7 +297,7 @@ def test_compact(bitcoind, directory, node_factory):
     tmp = tempfile.TemporaryDirectory()
     subprocess.check_call([cli_path, "restore", bdest, tmp.name])
 
-    # Trigger a couple more changes and the compact again.
+    # Trigger a couple more changes and then compact again.
     bitcoind.generate_block(100)
     sync_blockheight(bitcoind, [l1])
 


### PR DESCRIPTION
Continues #286

With this PR, calling `backup-compact` now returns (almost) immediate, without blocking c-lightning. Compaction runs in separate threat, while CL operates as normal.

basic principle:
1. record the latest `data_version` of current backup
2. compact up-to `data_version` into clone (here is the bulk of work and thread switching to handle `db_write` hook)
3. block `add_change` in main thread (this blocks CL), refresh latest `data_version` and
    make the clone catch-up with it by adding missing `versions`
4. atomically move clone-->backup and unblock

Before this PR, `backup-compact` call would return a dict `stats` when compaction completed.
Now it returns immediately `{"result": "compaction started"}`, `{"result": "compaction still in progress"}` or
`{"result": {"backupsize": <size_in_bytes>, "version_count": 2}}` when there is nothing to compact.
 The `stats` can be found in log, no idea who uses these.

All pretty much self-contained in `FileBackend`, so it also works with `SocketBackend` (which uses FileBackend on server side). The double logging issue #232 is also fixed, maybe this can be improved further, see task list.
Also includes some minor fixes/cleanups and comments, mostly for my own understanding.

I manual tested compacting + restoring a backup and `sqldiff` with original and also tested with remote SocketBackend.
With ld versions (v0.10.2+) that support "shutdown", an unfinished compaction (`.compacting` file) is cleaned up when shutting down. For users running `v0.10.2` before fix [#4959](https://github.com/ElementsProject/lightning/pull/4959), the plugin waits to be killed as last by the timeout in shutdown, seems prudent.

Also retired the deprecated `--backup-destination` option.

Todo:

- [x]  add tests
- ~make entire `FileBackend` thread safe, i.e. also `rewind`~ in retrospect, is overkill
- ~make all logs in FileBackend being forwarded by `SocketBackend`~ -> out of scope, server should handle these 
- [x] documentation, include example `systemd` script for weekly compacting

Other ideas:
- benchmark `backup.py` and compare with other backup methods
- replace `threading` with `multiprocessing`
- autocompact when backup size passes a threshold