### PR TITLE
New plugin: lnurlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Community curated plugins for c-lightning.
 | [graphql][graphql]                 | Exposes the c-lightning API over [graphql][graphql-spec]                                  |
 | [invoice-queue][invoice-queue]     | Listen to lightning invoices from multiple nodes and send to a redis queue for processing |
 | [lightning-qt][lightning-qt]       | A bitcoin-qt-like GUI for lightningd                                                      |
+| [lnurlp][lnurlp]                   | A plugin to handle lnurlp payRequest callbacks                                            |
 | [monitor][monitor]                 | helps you analyze the health of your peers and channels                                   |
 | [persistent-channels][pers-chans]  | Maintains a number of channels to peers                                                   |
 | [probe][probe]                     | Regularly probes the network for stability                                                |

--- a/lnurlp/README.md
+++ b/lnurlp/README.md
@@ -1,0 +1,146 @@
+# HTTP lnurlp plugin
+
+This plugin starts a minimal, rate limited HTTP server which returns an invoice on the following GET request:
+
+`/payRequest?amount=...`
+
+```
+$ curl http://localhost:8806/payRequest?amount=123123
+{"pr":"lnbc123123...","routes":[]}
+```
+
+The webserver is rate-limited, meaning that only a certain amount of request per minute per IP address is allowed, to mitigate DoS attacks.
+
+## lnurl payment flow
+
+The overall flow is documented in [LUD-06](https://github.com/fiatjaf/lnurl-rfc/blob/luds/06.md).
+
+Paying to static internet identifiers (the main use case) is described in [LUD-16](https://github.com/fiatjaf/lnurl-rfc/blob/luds/16.md). Basically, the `https://<domain>/.well-known/lnurlp/<username>` should return a JSON structure like:
+
+```javascript
+{
+    "status": "OK",
+    "callback": "https://domain.tld/path/to/payRequest",
+    "maxSendable": 100000000000,
+    "minSendable": 1000,
+    "commentAllowed": 0,
+    "metadata":"[[\"text/identifier\",\"user@domain.tld\"],[\"text/plain\",\"Donation to user@domain.tld.\"]]",
+    "tag": "payRequest"
+}
+```
+
+The callback URL `https://domain.tld/path/to/payRequest` is what is implemented by this plugin, generally it is reverse-proxied in the web server configuration to add TLS
+(or over Tor, see below). Exposing the HTTP port directly is not advised as it makes Man-in-the-Middle attacks trivial.
+
+It is important for value of the field `metadata` to be in sync between the web server and lightning plugin. This because a SHA256 hash of it is committed to in the `description_hash` of the returned invoice.
+
+## Reverse proxy in Nginx
+
+To set up the reverse proxy in Nginx put something like this under the `server` directive:
+
+```
+  location /payRequest {
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Proxy "";
+
+    proxy_pass http://127.0.0.1:8806/payRequest;
+    proxy_http_version 1.1;
+  }
+```
+
+Setting `X-Forwarded-For` and `X-Forwarded-Proto` headers is important to make sure that the end-user IP address is used for rate limiting, not localhost.
+
+## Tor onion service
+
+Exposing the URL using Onion routing is easy. Install Tor and add the service to `/etc/tor/torrc`
+
+```
+HiddenServiceDir /home/bitcoin/tor/lnurlp_service/
+HiddenServicePort 80 127.0.0.1:8806
+```
+
+and restart tor to create the URL:
+
+```
+$ systemctl stop tor && systemctl start tor
+$ cat /home/bitcoin/tor/lnurlp_service/hostname
+fkfuvjrbj...onion
+```
+
+Use Tor browser to visit the URL to test: `http://fkfuvjrbj...onion/payRequest?amount=...`.
+
+## Reverse-proxy over Tor
+
+Web servers generally don't support reverse-proxing over SOCKS (at least Nginx doesn't, at this time). To set this up, it can be useful to run `socat` as a bridge service.
+
+One way to do this is to create a file `/etc/systemd/system/http-to-socks-proxy@.service`:
+
+```
+[Unit]
+Description=HTTP-to-SOCKS proxy. Enables placing an HTTP proxy (e.g., nginx) in front of a SOCKS proxy (e.g., Tor).
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/http-to-socks-proxy/%i.conf
+ExecStart=/usr/bin/socat tcp4-LISTEN:${LOCAL_PORT},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS4A:${PROXY_HOST}:${REMOTE_HOST}:${REMOTE_PORT},socksport=${PROXY_PORT}
+
+[Install]
+WantedBy=multi-user.target
+```
+
+And `/etc/http-to-socks-proxy/lnurlp.conf`:
+
+```
+PROXY_HOST=127.0.0.1
+PROXY_PORT=9050
+LOCAL_PORT=8806
+REMOTE_HOST=fkfuvjrbj...onion
+REMOTE_PORT=8806
+```
+
+On the command line:
+
+```
+ln -s /etc/systemd/system/http-to-socks-proxy\@.service /etc/systemd/system/multi-user.target.wants/http-to-socks-proxy\@lnurlp.service
+systemctl daemon-reload
+systemctl start http-to-socks-proxy@lnurlp.service
+systemctl status http-to-socks-proxy@lnurlp.service
+```
+
+This will forward `http://127.0.0.1:8806` to the onion service over Tor. Reverse-proxying is otherwise the same.
+
+## Configuration
+
+The only necessary configuration is the path to the endpoint JSON file (e.g. `/home/www/host/.well-known/lnurlp/jsonfile`) for the `metadata`
+field:
+
+- `--lnurlp-meta-path=...`
+
+(optional) You can make the plugin use a specific port and address:
+
+- `--lnurlp-address=... (default 127.0.0.1)`
+- `--lnurlp-port=... (default 8806)`
+
+(optional) You can set the rate of the rate limiter, or disable it:
+
+Rate limits are specified as strings following the format:
+```
+[count] [per|/] [n (optional)] [second|minute|hour|day|month|year]
+```
+
+You can combine multiple rate limits by separating them with a delimiter of your choice.
+
+e.g.:
+
+- `--lnurlp-ratelimit="1 per minute"`
+- `--lnurlp-ratelimit="10/hour"`
+- `--lnurlp-ratelimit="2 per 2 minutes;3 per hour;42 per day"`
+- `--lnurlp-ratelimit="100/day, 500/2months"`
+
+Default is "2 per minute".
+
+To disable rate limiting:
+
+- `--lnurlp-ratelimit="disable"`

--- a/lnurlp/lnurlp.py
+++ b/lnurlp/lnurlp.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+from flask import Flask, request
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+from pyln.client import Plugin
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
+from tornado.wsgi import WSGIContainer
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+
+import asyncio
+import hashlib
+import json
+import os
+import threading
+import uuid
+
+metadata = ""
+plugin = Plugin()
+app = Flask(__name__)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
+
+jobs = {}
+
+
+@app.route('/payRequest')
+def payRequestUrl():
+    global plugin
+    amount = int(request.args.get('amount'))
+    label = "ln-lnurlp-{}".format(uuid.uuid4())
+
+    invoice = plugin.rpc.invoice(amount, label, "", description_hash=plugin.description_hash)
+
+    return {'pr': invoice['bolt11'], 'routes': []}
+
+
+def worker(address, port):
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+    print('Starting server on port {port}'.format(
+        port=port
+    ))
+    app.config['SECRET_KEY'] = os.getenv(
+        "REQUEST_INVOICE_SECRET",
+        default=uuid.uuid4())
+
+    http_server = HTTPServer(WSGIContainer(app))
+    http_server.listen(port, address)
+    IOLoop.instance().start()
+
+
+def start_server(address, port):
+    if port in jobs:
+        raise ValueError("server already running on port {port}".format(port=port))
+
+    p = threading.Thread(
+        target=worker, args=(address, port), daemon=True)
+
+    jobs[port] = p
+    p.start()
+
+
+@plugin.init()
+def init(options, configuration, plugin):
+    plugin.address = options["lnurlp-addr"]
+    plugin.port = int(options["lnurlp-port"])
+    ratelimit = options.get("lnurlp-ratelimit", "2 per minute")
+
+    if ratelimit != "disable":
+        limiter = Limiter(
+            app,
+            key_func=get_remote_address
+        )
+        limiter.limit(ratelimit)(payRequestUrl)
+
+    try:
+        with open(options["lnurlp-meta-path"], 'r') as f:
+            metadata = json.load(f)['metadata'].encode()
+            plugin.description_hash = hashlib.sha256(metadata).hexdigest()
+    except FileNotFoundError:
+        if options["lnurlp-meta-path"] == "":
+            raise Exception("Please add a path to the webserver's json with --lnurlp-meta-path=...")
+        else:
+            raise Exception("File not found!")
+
+    start_server(plugin.address, plugin.port)
+
+
+plugin.add_option(
+    "lnurlp-addr",
+    "127.0.0.1",
+    "Manually set the address to be used for the lnurlp-plugin, default is 127.0.0.1"
+)
+
+plugin.add_option(
+    "lnurlp-port",
+    "8806",
+    "Manually set the port to be used for the lnurlp-plugin, default is 8806"
+)
+
+plugin.add_option(
+    "lnurlp-meta-path",
+    "",
+    "Path of the webserver's lnurlp-JSON-file"
+)
+
+plugin.add_option(
+    "lnurlp-ratelimit",
+    "2 per minute",
+    "Set flask's rate limiter, default is '2 per minute', 'disable' to disable"
+)
+
+plugin.run()

--- a/lnurlp/requirements.txt
+++ b/lnurlp/requirements.txt
@@ -1,0 +1,6 @@
+python-dotenv>=0.13.0
+flask==1.1.4
+flask-limiter
+tornado
+pyln-client
+requests

--- a/lnurlp/test_lnurlp.py
+++ b/lnurlp/test_lnurlp.py
@@ -1,0 +1,35 @@
+import os
+from pyln.testing.fixtures import *  # noqa: F401,F403
+import requests
+from subprocess import check_output
+import tempfile
+
+plugin_path = os.path.join(os.path.dirname(__file__), "lnurlp.py")
+
+
+def test_lnurlp_starts(node_factory):
+    tempmeta = tempfile.NamedTemporaryFile()
+    tempmeta.write(b'{"metadata":"justfortestingpurposes"}')
+    tempmeta.seek(0)
+
+    l1 = node_factory.get_node(options={"plugin": plugin_path, "lnurlp-meta-path": tempmeta.name})
+
+    l1.daemon.logsearch_start = 0
+    l1.daemon.wait_for_log(r'Starting server on port 8806')
+
+    r = requests.get('http://localhost:8806/payRequest?amount=123')
+
+    # check for hanging process if status_code = 500
+    assert(r.status_code == 200)
+
+    # returned valid  invoice?
+    b = r.json()
+    assert(b['pr'].startswith("lnbcrt123"))
+
+    # test rate-limit
+    for i in range(0,20):
+        r = requests.get('http://localhost:8806/payRequest?amount=123')
+    assert(r.status_code == 429)
+    assert("429 Too Many Requests" in r.text )
+
+    tempmeta.close()


### PR DESCRIPTION
A simple http server to retrieve pay requests (bolt11s at the moment) to be used in lnurls

Based on the request-invoice plugin: it made sense to create a new plugin because having only one endpoint makes things more simple and secure
This one needs description_hash, while the request-invoice endpoint doesn't which would complicate things

Co-authored-by: W. J. van der Laan