### PR TITLE
rebalancereport calls listpays once

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -742,9 +742,13 @@ def rebalancereport(plugin: Plugin):
     total_fee = Millisatoshi(0)
     total_amount = Millisatoshi(0)
     res["total_successful_rebalances"] = len(rebalances)
+    # pyln-client does not support the 'status' argument as yet
+    # pays = plugin.rpc.listpays(status="complete")["pays"]
+    pays = plugin.rpc.listpays()["pays"]
+    pays = [p for p in pays if p.get('status') == 'complete']
     for r in rebalances:
         try:
-            pay = plugin.rpc.listpays(r["bolt11"])["pays"][0]
+            pay = next(p for p in pays if p["payment_hash"] == r["payment_hash"])
             total_amount += pay["amount_msat"]
             total_fee += pay["amount_sent_msat"] - pay["amount_msat"]
         except Exception:

--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -448,7 +448,7 @@ def feeadjust_would_be_nice(plugin: Plugin):
 
 
 def get_max_amount(i: int, plugin: Plugin):
-    return max(plugin.min_amount, plugin.enough_liquidity / (4**(i + 1)))
+    return max(plugin.min_amount, plugin.enough_liquidity / (4**i))
 
 
 def get_max_fee(plugin: Plugin, msat: Millisatoshi):


### PR DESCRIPTION
I had several successful rebalances, and when I call `rebalancereport` it takes some time to collect info about them.
A possible performance improvement: `rebalancereport` does not call `listpays` for every rebalance one by one, but only once.
In my case, this changes the execution time from ~140 secs to ~7 secs.