### PR TITLE
Add listmempoolfunds plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "go-lnmetrics.reporter"]
 	path = go-lnmetrics.reporter
 	url = https://github.com/LNOpenMetrics/go-lnmetrics.reporter.git
+[submodule "listmempoolfunds"]
+	path = listmempoolfunds
+	url = https://github.com/andrewtoth/listmempoolfunds

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Community curated plugins for c-lightning.
 | [graphql][graphql]                   | Exposes the c-lightning API over [graphql][graphql-spec]                                  |
 | [invoice-queue][invoice-queue]       | Listen to lightning invoices from multiple nodes and send to a redis queue for processing |
 | [lightning-qt][lightning-qt]         | A bitcoin-qt-like GUI for lightningd                                                      |
+| [listmempoolfunds][listmempoolfunds] | A replacement for listfunds that includes unconfirmed received outputs in the mempool     |
 | [monitor][monitor]                   | helps you analyze the health of your peers and channels                                   |
 | [persistent-channels][pers-chans]    | Maintains a number of channels to peers                                                   |
 | [probe][probe]                       | Regularly probes the network for stability                                                |
@@ -186,6 +187,7 @@ Python plugins developers must ensure their plugin to work with all Python versi
 [graphql]: https://github.com/nettijoe96/c-lightning-graphql
 [graphql-spec]: https://graphql.org/
 [lightning-qt]: https://github.com/darosior/pylightning-qt
+[listmempoolfunds]: https://github.com/andrewtoth/listmempoolfunds
 [cpp-api]: https://github.com/darosior/lightningcpp
 [js-api]: https://github.com/lightningd/clightningjs
 [monitor]: https://github.com/renepickhardt/plugins/tree/master/monitor

--- a/README.md
+++ b/README.md
@@ -6,39 +6,39 @@ Community curated plugins for c-lightning.
 
 ## Available plugins
 
-| Name                               | Short description                                                                         |
-|------------------------------------|-------------------------------------------------------------------------------------------|
-| [autopilot][autopilot]             | An autopilot that suggests channels that should be established                            |
-| [backup][backup]                   | A simple and reliable backup plugin                                                       |
-| [boltz-channel-creation][boltz]    | A c-lightning plugin for Boltz Channel Creation Swaps                                     |
-| [btcli4j][btcli4j]                 | A Bitcoin Backend to enable safely the pruning mode, and support also rest APIs.          |
-| [commando][commando]               | Authorize peers to run commands on your node, and running commands on them.   |
-| [csvexportpays][csvexportpays]     | A plugin that exports all payments to a CSV file                                          |
-| [currencyrate][currencyrate]       | A plugin to convert other currencies to BTC using web requests                            |
-| [donations][donations]             | A simple donations page to accept donations from the web                                  |
-| [drain][drain]                     | Draining, filling and balancing channels with automatic chunks.                           |
-| [event-websocket][event-websocket] | Exposes notifications over a Websocket                                                    |
-| [feeadjuster][feeadjuster]         | Dynamic fees to keep your channels more balanced                                          |
-| [go-lnmetrics.reporter][reporter]  | Collect and report of the lightning node metrics                                          |
-| [graphql][graphql]                 | Exposes the c-lightning API over [graphql][graphql-spec]                                  |
-| [invoice-queue][invoice-queue]     | Listen to lightning invoices from multiple nodes and send to a redis queue for processing |
-| [lightning-qt][lightning-qt]       | A bitcoin-qt-like GUI for lightningd                                                      |
-| [monitor][monitor]                 | helps you analyze the health of your peers and channels                                   |
-| [persistent-channels][pers-chans]  | Maintains a number of channels to peers                                                   |
-| [probe][probe]                     | Regularly probes the network for stability                                                |
-| [prometheus][prometheus]           | Lightning node exporter for the prometheus timeseries server                              |
-| [pruning][pruning]                 | This plugin manages pruning of bitcoind such that it can always sync                      |
-| [rebalance][rebalance]             | Keeps your channels balanced                                                              |
-| [reckless][reckless]               | An **experimental** plugin manager (search/install plugins)                               |
-| [requestinvoice][request-invoice]  | Http server to request invoices                                                           |
-| [sauron][sauron]                   | A Bitcoin backend relying on [Esplora][esplora]'s API                                     |
-| [sitzprobe][sitzprobe]             | A Lightning Network payment rehearsal utility                                             |
-| [sparko][sparko]                   | RPC over HTTP with fine-grained permissions, SSE and spark-wallet support                 |
-| [summary][summary]                 | Print a nice summary of the node status                                                   |
-| [trustedcoin][trustedcoin]         | Replace your Bitcoin Core with data from public block explorers                           |
-| [webhook][webhook]                 | Dispatches webhooks based from [event notifications][event-notifications]                 |
-| [watchtower][teos-client]          | Watchtower client for The Eye of Satoshi                                                  |
-| [zmq][zmq]                         | Publishes notifications via [ZeroMQ][zmq-home] to configured endpoints                    |
+| Name                                 | Short description                                                                         |
+|--------------------------------------|-------------------------------------------------------------------------------------------|
+| [autopilot][autopilot]               | An autopilot that suggests channels that should be established                            |
+| [backup][backup]                     | A simple and reliable backup plugin                                                       |
+| [boltz-channel-creation][boltz]      | A c-lightning plugin for Boltz Channel Creation Swaps                                     |
+| [btcli4j][btcli4j]                   | A Bitcoin Backend to enable safely the pruning mode, and support also rest APIs.          |
+| [commando][commando]                 | Authorize peers to run commands on your node, and running commands on them.   |
+| [csvexportpays][csvexportpays]       | A plugin that exports all payments to a CSV file                                          |
+| [currencyrate][currencyrate]         | A plugin to convert other currencies to BTC using web requests                            |
+| [donations][donations]               | A simple donations page to accept donations from the web                                  |
+| [drain][drain]                       | Draining, filling and balancing channels with automatic chunks.                           |
+| [event-websocket][event-websocket]   | Exposes notifications over a Websocket                                                    |
+| [feeadjuster][feeadjuster]           | Dynamic fees to keep your channels more balanced                                          |
+| [go-lnmetrics.reporter][reporter]    | Collect and report of the lightning node metrics                                          |
+| [graphql][graphql]                   | Exposes the c-lightning API over [graphql][graphql-spec]                                  |
+| [invoice-queue][invoice-queue]       | Listen to lightning invoices from multiple nodes and send to a redis queue for processing |
+| [lightning-qt][lightning-qt]         | A bitcoin-qt-like GUI for lightningd                                                      |
+| [monitor][monitor]                   | helps you analyze the health of your peers and channels                                   |
+| [persistent-channels][pers-chans]    | Maintains a number of channels to peers                                                   |
+| [probe][probe]                       | Regularly probes the network for stability                                                |
+| [prometheus][prometheus]             | Lightning node exporter for the prometheus timeseries server                              |
+| [pruning][pruning]                   | This plugin manages pruning of bitcoind such that it can always sync                      |
+| [rebalance][rebalance]               | Keeps your channels balanced                                                              |
+| [reckless][reckless]                 | An **experimental** plugin manager (search/install plugins)                               |
+| [requestinvoice][request-invoice]    | Http server to request invoices                                                           |
+| [sauron][sauron]                     | A Bitcoin backend relying on [Esplora][esplora]'s API                                     |
+| [sitzprobe][sitzprobe]               | A Lightning Network payment rehearsal utility                                             |
+| [sparko][sparko]                     | RPC over HTTP with fine-grained permissions, SSE and spark-wallet support                 |
+| [summary][summary]                   | Print a nice summary of the node status                                                   |
+| [trustedcoin][trustedcoin]           | Replace your Bitcoin Core with data from public block explorers                           |
+| [webhook][webhook]                   | Dispatches webhooks based from [event notifications][event-notifications]                 |
+| [watchtower][teos-client]            | Watchtower client for The Eye of Satoshi                                                  |
+| [zmq][zmq]                           | Publishes notifications via [ZeroMQ][zmq-home] to configured endpoints                    |
 
 ## Installation
 


### PR DESCRIPTION
This plugin is motivated by https://github.com/ElementsProject/lightning/issues/2104. Using `listmempoolfunds` instead of `listfunds`, a user can monitor received unconfirmed txs.