### PR TITLE
another instance of unchecked short_channel_id access in fee_strategy: get_fees_median

### DIFF
--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -66,7 +66,7 @@ def get_ratio_hard(our_percentage):
 def get_peer_id_for_scid(plugin: Plugin, scid: str):
     for peer in plugin.peers:
         for ch in peer['channels']:
-            for ch in peer['channels']:
+            if 'short_channel_id' in ch:
                 if ch['short_channel_id'] == scid:
                     return peer['id']
     return None

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -66,8 +66,9 @@ def get_ratio_hard(our_percentage):
 def get_peer_id_for_scid(plugin: Plugin, scid: str):
     for peer in plugin.peers:
         for ch in peer['channels']:
-            if ch['short_channel_id'] == scid:
-                return peer['id']
+            for ch in peer['channels']:
+                if ch['short_channel_id'] == scid:
+                    return peer['id']
     return None
 
 

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -74,8 +74,9 @@ def get_peer_id_for_scid(plugin: Plugin, scid: str):
 def get_local_channel_for_scid(plugin: Plugin, scid: str):
     for peer in plugin.peers:
         for ch in peer['channels']:
-            if ch['short_channel_id'] == scid:
-                return ch
+            if 'short_channel_id' in ch:
+                if ch['short_channel_id'] == scid:
+                    return ch
     return None
 
 


### PR DESCRIPTION
Crashed again for me, this time I assume it is due to me changing the fee strategy to "median" (see stack trace)
Maybe all reads of 'short_channel_id' should be checked?

Also sorry for my incompetence in operating git, to me this shows as 3 commits now m(

```
2022-01-27T16:49:42.133Z INFO    plugin-feeadjuster.py: Plugin feeadjuster initialized (0 base / 250 ppm) with an imbalance of 50%/50%, update_threshold: 5%, update_threshold_abs: 100000000msat, enough_liquidity: 0msat, deactivate_fuzz: None, forward_event_subscription: True, adjustment_method: get_ratio, fee_strategy: get_fees_median, listchannels_by_dst: True
2022-01-27T16:49:42.183Z INFO    [...]-chan#21877: State changed from FUNDING_SPEND_SEEN to ONCHAIN
2022-01-27T16:49:42.907Z INFO    plugin-feeadjuster.py: Adjusted fees of [...]x0 with a ratio of...
2022-01-27T16:49:44.049Z INFO    plugin-feeadjuster.py: Adjusted fees of [...]0 with a ratio of ...
2022-01-27T16:49:44.618Z INFO    plugin-feeadjuster.py: Adjusted fees of [...]x0 with a ratio of...
2022-01-27T16:49:44.718Z UNUSUAL plugin-plugin.js: --- Starting the cl-rest server ---
2022-01-27T16:49:44.782Z UNUSUAL plugin-plugin.js: --- cl-rest api server is ready and listening on port: 3001 ---
2022-01-27T16:49:44.782Z UNUSUAL plugin-plugin.js: --- cl-rest doc server is ready and listening on port: 4001 ---
2022-01-27T16:49:44.976Z INFO    plugin-feeadjuster.py: Adjusted fees of [...] with a ratio of...
2022-01-27T16:49:45.102Z INFO    plugin-feeadjuster.py: Traceback (most recent call last):
2022-01-27T16:49:45.103Z INFO    plugin-feeadjuster.py:   File \"/home/ln/.local/lib/python3.6/site-packages/pyln/client/plugin.py\", line 621, in _dispatch_request
2022-01-27T16:49:45.104Z INFO    plugin-feeadjuster.py:     result = self._exec_func(method.func, request)
2022-01-27T16:49:45.106Z INFO    plugin-feeadjuster.py:   File \"/home/ln/.local/lib/python3.6/site-packages/pyln/client/plugin.py\", line 606, in _exec_func
2022-01-27T16:49:45.106Z INFO    plugin-feeadjuster.py:     return func(*ba.args, **ba.kwargs)
2022-01-27T16:49:45.107Z INFO    plugin-feeadjuster.py:   File \"/home/ln/.local/lib/python3.6/site-packages/pyln/client/plugin.py\", line 845, in _init
2022-01-27T16:49:45.107Z INFO    plugin-feeadjuster.py:     return self._exec_func(self.child_init, request)
2022-01-27T16:49:45.108Z INFO    plugin-feeadjuster.py:   File \"/home/ln/.local/lib/python3.6/site-packages/pyln/client/plugin.py\", line 606, in _exec_func
2022-01-27T16:49:45.109Z INFO    plugin-feeadjuster.py:     return func(*ba.args, **ba.kwargs)
2022-01-27T16:49:45.109Z INFO    plugin-feeadjuster.py:   File \"/home/ln/plugins/feeadjuster/feeadjuster.py\", line 316, in init
2022-01-27T16:49:45.111Z INFO    plugin-feeadjuster.py:     feeadjust(plugin)
2022-01-27T16:49:45.111Z INFO    plugin-feeadjuster.py:   File \"/home/ln/plugins/feeadjuster/feeadjuster.py\", line 245, in feeadjust
2022-01-27T16:49:45.112Z INFO    plugin-feeadjuster.py:     channels_adjusted += maybe_adjust_fees(plugin, [_scid])
2022-01-27T16:49:45.113Z INFO    plugin-feeadjuster.py:   File \"/home/ln/plugins/feeadjuster/feeadjuster.py\", line 154, in maybe_adjust_fees
2022-01-27T16:49:45.113Z INFO    plugin-feeadjuster.py:     fees = plugin.fee_strategy(plugin, scid)
2022-01-27T16:49:45.114Z INFO    plugin-feeadjuster.py:   File \"/home/ln/plugins/feeadjuster/feeadjuster.py\", line 98, in get_fees_median
2022-01-27T16:49:45.115Z INFO    plugin-feeadjuster.py:     peer_id = get_peer_id_for_scid(plugin, scid)
2022-01-27T16:49:45.115Z INFO    plugin-feeadjuster.py:   File \"/home/ln/plugins/feeadjuster/feeadjuster.py\", line 69, in get_peer_id_for_scid
2022-01-27T16:49:45.119Z INFO    plugin-feeadjuster.py:     if ch['short_channel_id'] == scid:
2022-01-27T16:49:45.120Z INFO    plugin-feeadjuster.py: KeyError: 'short_channel_id'
2022-01-27T16:49:45.120Z INFO    plugin-feeadjuster.py: 
2022-01-27T16:50:36.863Z UNUSUAL plugin-bcli: bitcoin-cli: finished bitcoin-cli getblock 0000000000000000000432a9dc150026aabbbaef8ceb3ee342f545603d77dcf6 0 (10603 ms)
```
