### PR TITLE
fix: autopilot

### DIFF
--- a/autopilot/autopilot.py
+++ b/autopilot/autopilot.py
@@ -28,7 +28,7 @@ class CLightning_autopilot(Autopilot):
         retrieve the nodeids of the ln seed nodes from lseed.bitcoinstats.com
         """
         domain = "lseed.bitcoinstats.com"
-        srv_records = dns.resolver.query(domain, "SRV")
+        srv_records = dns.resolver.resolve(domain, "SRV")
         res = []
         for srv in srv_records:
             bech32 = str(srv.target).rstrip(".").split(".")[0]

--- a/autopilot/autopilot.py
+++ b/autopilot/autopilot.py
@@ -54,7 +54,7 @@ class CLightning_autopilot(Autopilot):
                 # FIXME: better strategy than sleep(2) for building up
                 time.sleep(2)
             except RpcError as e:
-                plugin.log(f"Unable to connect to node: {nodeid}  {str(e)}", 'error')
+                plugin.log(f"Unable to connect to node: {nodeid}  {str(e)}", 'warn')
 
     def __download_graph(self):
         """

--- a/autopilot/lib_autopilot.py
+++ b/autopilot/lib_autopilot.py
@@ -243,6 +243,7 @@ class Autopilot():
             path_pdf[node] = path_sum
 
         s = sum(path_pdf.values())
+        # FIXME: next line can raise a division by zero
         path_pdf = {k: v / s for k, v in path_pdf.items()}
         self.__logger.info(
             "DECREASE DIAMETER: probability density function created")

--- a/autopilot/test_autopilot.py
+++ b/autopilot/test_autopilot.py
@@ -1,6 +1,8 @@
 import os
 from pyln.testing.fixtures import *  # noqa: F401,F403
-import pytest
+import unittest
+
+CI = os.environ.get('CI') in ('True', 'true')
 
 plugin_path = os.path.join(os.path.dirname(__file__), "autopilot.py")
 plugin_opt = {'plugin': plugin_path}
@@ -17,8 +19,10 @@ def test_starts(node_factory):
     l1.daemon.opts["plugin"] = plugin_path
     l1.start()
 
-@pytest.mark.skipIf(True, "Test autopilot is hanging on DNS request")
+
+@unittest.skipIf(CI, "Test autopilot is hanging on DNS request")
 def test_main(node_factory):
     l1, l2 = node_factory.line_graph(2, wait_for_announce=True, opts=plugin_opt)
     # just call main function
-    #assert l1.rpc.autopilot_run_once()
+    l1.rpc.autopilot_run_once(dryrun=True)
+    l1.daemon.wait_for_log("I'd like to open [0-9]* new channels with [0-9]* satoshis each")


### PR DESCRIPTION
fixes several (not all) testing issues we had with the autopilot plugin.

- fixed a test annotation and CI detection
- fixed a dns.resolver.query deprecation
- added a remark for a possible division by zero (not fixed yet)
- I set the repeated "unable to connect" message to just log-level "warn" so they don't appear as teardown BROKEN errors.
