### PR TITLE
include node alias in node metrics

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -45,10 +45,10 @@ class FundsCollector(BaseLnCollector):
         funds = self.rpc.listfunds()
         print(funds['outputs'])
         output_funds = sum(
-            [o['amount_msat'].to_satoshi() for o in funds['outputs']]
+            [o['amount_msat'].to_satoshi() for o in funds['outputs'] if o['reserved']!='true']
         )
         channel_funds = sum(
-            [c['our_amount_msat'].to_satoshi() for c in funds['channels']]
+                [c['our_amount_msat'].to_satoshi() for c in funds['channels'] if c['state']!='ONCHAIN']
         )
         total = output_funds + channel_funds
 

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -45,10 +45,10 @@ class FundsCollector(BaseLnCollector):
         funds = self.rpc.listfunds()
         print(funds['outputs'])
         output_funds = sum(
-            [o['amount_msat'].to_satoshi() for o in funds['outputs'] if o['reserved']!='true']
+            [o['amount_msat'].to_satoshi() for o in funds['outputs']]
         )
         channel_funds = sum(
-                [c['our_amount_msat'].to_satoshi() for c in funds['channels'] if c['state']!='ONCHAIN']
+            [c['our_amount_msat'].to_satoshi() for c in funds['channels']]
         )
         total = output_funds + channel_funds
 

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -76,16 +76,22 @@ class PeerCollector(BaseLnCollector):
         connected = GaugeMetricFamily(
             'lightning_peer_connected',
             'Is the peer currently connected?',
-            labels=['id'],
+            labels=['id', 'alias'],
         )
         count = GaugeMetricFamily(
             'lightning_peer_channels',
             "The number of channels with the peer",
-            labels=['id'],
+            labels=['id', 'alias'],
         )
 
         for p in peers:
-            labels = [p['id']]
+            node = self.rpc.listnodes(p['id'])['nodes']
+            if len(node) != 0 and 'alias' in node[0]:
+                alias = node[0]['alias']
+            else:
+                alias = 'unknown'
+
+            labels = [p['id'], alias]
             count.add_metric(labels, len(p['channels']))
             connected.add_metric(labels, int(p['connected']))
 

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -76,22 +76,16 @@ class PeerCollector(BaseLnCollector):
         connected = GaugeMetricFamily(
             'lightning_peer_connected',
             'Is the peer currently connected?',
-            labels=['id', 'alias'],
+            labels=['id'],
         )
         count = GaugeMetricFamily(
             'lightning_peer_channels',
             "The number of channels with the peer",
-            labels=['id', 'alias'],
+            labels=['id'],
         )
 
         for p in peers:
-            node = self.rpc.listnodes(p['id'])['nodes']
-            if len(node) != 0 and 'alias' in node[0]:
-                alias = node[0]['alias']
-            else:
-                alias = 'unknown'
-
-            labels = [p['id'], alias]
+            labels = [p['id']]
             count.add_metric(labels, len(p['channels']))
             connected.add_metric(labels, int(p['connected']))
 


### PR DESCRIPTION
I understand that the alias is unreliable and everything, but having it for channels but not for nodes is what I don't get. IF alias is used, it should be as a property of the node, which this introduces.
Also having to work with hundreds of SCIDs is very difficult, so I like the alias.