### PR TITLE
commando: fixes `requirements.txt` for a plugin

### DIFF
--- a/commando/requirements.txt
+++ b/commando/requirements.txt
@@ -1,1 +1,2 @@
 runes>=0.4
+pyln-client>=0.10.1


### PR DESCRIPTION
In a clean machine a new user will endup with the following exception

```
Traceback (most recent call last):
  File "/home/lightning/.lightning/plugins/commando.py", line 22, in <module>
    from pyln.client import Plugin, RpcError  # type: ignore
ModuleNotFoundError: No module named 'pyln'
```

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>