### PR TITLE
prometheus: Listen on 127.0.0.1 by default

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -5,8 +5,8 @@ so it can be scraped, plotted and alerts can be created on it. The plugin adds
 the following command line arguments:
 
  - `prometheus-listen`: the IP address and port to bind the HTTP server to
-   (default: `0.0.0.0:9750`)
-   
+   (default: `127.0.0.1:9750`)
+
 Exposed variables include:
 
  - `node`: ID, version, ...

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -220,7 +220,7 @@ def init(options, configuration, plugin):
 
 plugin.add_option(
     'prometheus-listen',
-    '0.0.0.0:9750',
+    '127.0.0.1:9750',
     'Address and port to bind to'
 )
 


### PR DESCRIPTION
Make the prometheus plugin listen on 127.0.0.1 (localhost) by default instead of open to the world. This closes a privacy breach in the default configuration.