### PR TITLE
Added `allmsgs` command to noise to print all msgs

### DIFF
--- a/noise/README.org
+++ b/noise/README.org
@@ -21,12 +21,18 @@ lightning-cli sendmsg 02a5deaa47804c518bb4a1c6f04a85b92b796516bd32c4114a51b00d73
 You can read the last message received using the following command:
 
 #+BEGIN_SRC bash
-lightning-cli recvmsg last_id
+lightning-cli recvmsg msg_id
 #+END_SRC
 
-The ~last_id~ indicates the last message we read, so we can retrieve each message
-individually. If you'd just like to wait for the next message then do not
-specify any ~last_id~.
+The ~msg_id~ indicates the id number of each message received in chronological
+order, so we can retrieve each message individually. If you'd just like to wait
+for the next message then do not specify any ~msg_id~.
+
+You can output all messages received using the following command:
+
+#+BEGIN_SRC bash
+lightning-cli allmsgs
+#+END_SRC
 
 * Todo
 

--- a/noise/noise.py
+++ b/noise/noise.py
@@ -166,6 +166,19 @@ def sendmsg(node_id, msg, plugin, request, pay=None, **kwargs):
     request.set_result(res)
 
 
+@plugin.async_method('allmsgs')
+def allmsgs(plugin, request, **kwargs):
+    """
+    Prints all messages that have been received
+    """
+    msg_list = {}
+    for i in range(len(plugin.messages)):
+        res = plugin.messages[int(i)].to_dict()
+        res['total_messages'] = len(plugin.messages)
+        msg_list["message"+str(i)] = res
+    request.set_result(msg_list)
+
+
 @plugin.async_method('recvmsg')
 def recvmsg(plugin, request, msg_id=None, **kwargs):
     """Receives a chat message.


### PR DESCRIPTION
I have been wanting to add this for a while, but I wanted to wait to see how things would end up with the poetry updates. I'm sorry, I don't know how to write effective tests. All I can really do is reverse engineer existing code and try to hack it into doing something I want. I also updated the readme to change \~last_id\~ to \~msg_id\~ since it was changed like that in the code.