### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM elementsproject/lightningd
+ARG CLN_VERSION="0.11.1"
+
+FROM elementsproject/lightningd:v${CLN_VERSION}
 
 ARG EXTRA_PLUGINS='--recurse-submodules=csvexportpays \
 --recurse-submodules=graphql \
@@ -7,17 +9,29 @@ ARG EXTRA_PLUGINS='--recurse-submodules=csvexportpays \
 --recurse-submodules=trustedcoin \
 --recurse-submodules=webhook'
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential python3-wheel python3-dev python3-venv libleveldb-dev pkg-config libc-bin git libpq-dev postgresql
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3-wheel \
+    python3-dev \
+    python3-venv \
+    libleveldb-dev \
+    pkg-config \
+    libc-bin \
+    git \
+    libpq-dev \
+    postgresql \
+    curl && \
+    python3 -m pip install --upgrade pip
 
 COPY . /tmp/plugins
-RUN mkdir /tmp/oldplugins && mv /opt/lightningd/plugins/* /tmp/oldplugins/ && \
-    cd /opt/lightningd/plugins && \
+RUN mkdir /tmp/oldplugins && mv /usr/local/libexec/c-lightning/plugins/* /tmp/oldplugins/ && \
+    cd /usr/local/libexec/c-lightning/plugins && \
     git clone --depth 1 --shallow-submodules -j4 \
         ${EXTRA_PLUGINS} \
         file:///tmp/plugins . && \
     pip3 install setuptools && \
-    find -name requirements.txt -exec pip3 install -r {} \; && \
-    mv /tmp/oldplugins/* /opt/lightningd/plugins/ && rmdir /tmp/oldplugins
+    find -name requirements.txt -print0 | xargs -0 -n 1 pip3 install -r && \
+    mv /tmp/oldplugins/* /usr/local/libexec/c-lightning/plugins && rmdir /tmp/oldplugins
 
 EXPOSE 9735 9835
 ENTRYPOINT  [ "/usr/bin/tini", "-g", "--", "./entrypoint.sh" ]


### PR DESCRIPTION
This PR fixes a few things in the Dockerfile.

- allows hardcoding of the lightningd image to avoid breaking the Dockerfile randomly
- updates pip after install to fix issues with Pillow install later
- updates the location of the plugins in the image since the upstream lightningd image moved them
- update python requirements install to allow it to fail when dependency install fails