### PR TITLE
summary: use lowercase in bitstamp api

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -69,7 +69,7 @@ class PriceThread(threading.Thread):
                 # NOTE: Bitstamp has a DNS/Proxy issues that can return 404
                 # Workaround: retry up to 5 times with a delay
                 for _ in range(5):
-                    r = requests.get('https://www.bitstamp.net/api/v2/ticker/BTC{}'.format(plugin.currency), proxies=self.proxies)
+                    r = requests.get('https://www.bitstamp.net/api/v2/ticker/btc{}'.format(plugin.currency.lower()), proxies=self.proxies)
                     if not r.status_code == 200:
                         time.sleep(1)
                         continue


### PR DESCRIPTION
Bitstamp API wants lower case:
https://www.bitstamp.net/api/#ticker

Doesn't work:
https://www.bitstamp.net/api/v2/ticker/BTCUSD/

Works:
https://www.bitstamp.net/api/v2/ticker/btcusd/