### PR TITLE
backup: doc use poetry run also for backup-cli cmd

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -26,7 +26,7 @@ which makes sure no two instances are using the same backup. (Make sure to stop
 your Lightning node before running this command)
 
 ```bash
-./backup-cli init --lightning-dir ~/.lightning/bitcoin file:///mnt/external/location/file.bkp
+poetry run ./backup-cli init --lightning-dir ~/.lightning/bitcoin file:///mnt/external/location/file.bkp
 ```
 
 Notes:


### PR DESCRIPTION
This simply got missed.
On a fresh install, the command will fail without poetry environment.