### PR TITLE
Add referenced requirements.txt for backup plugin

### DIFF
--- a/backup/requirements.txt
+++ b/backup/requirements.txt
@@ -1,0 +1,2 @@
+pyln-client
+psutil


### PR DESCRIPTION
This file is referenced in https://lightning.readthedocs.io/BACKUP.html#backup-plugin-and-remote-nfs-mount, but does not exist, making installation and usage of backup plugin much more tricky.

This commit simply adds the two required packages so that the docs are correct now and the plugin can be more easily installed.