### PR TITLE
increase pyln-client version in summary

### DIFF
--- a/summary/requirements.txt
+++ b/summary/requirements.txt
@@ -1,4 +1,4 @@
-pyln-client>=0.12
+pyln-client>=0.12.1
 requests>=2.10.0
 requests[socks]>=2.10.0
 packaging>=14.1


### PR DESCRIPTION
This should fix the summary with the last version if cln.

Currently summary is crashing on my node, and just install the new version of the pyln-client to get it working again.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>