### PR TITLE
fix cli upstream changes for `listpeerchannels`

### DIFF
--- a/donations/donations.py
+++ b/donations/donations.py
@@ -27,7 +27,7 @@ from io import BytesIO
 from pyln.client import Plugin
 from random import random
 from wtforms import StringField, SubmitField, IntegerField
-from wtforms.validators import Required, NumberRange
+from wtforms.validators import DataRequired, NumberRange
 
 
 plugin = Plugin()
@@ -36,7 +36,7 @@ plugin = Plugin()
 class DonationForm(FlaskForm):
     """Form for donations """
     amount = IntegerField("Enter how many Satoshis you want to donate!",
-                          validators=[Required(), NumberRange(min=1, max=16666666)])
+                          validators=[DataRequired(), NumberRange(min=1, max=16666666)])
     description = StringField("Leave a comment (displayed publically)")
     submit = SubmitField('Donate')
 

--- a/donations/donations.py
+++ b/donations/donations.py
@@ -76,7 +76,7 @@ def donation_form():
     if form.validate_on_submit():
         amount = form.amount.data
         description = form.description.data
-        label = "ln-plugin-donation-{}".format(random())
+        label = "ln-plugin-donations-{}".format(random())
         invoice = plugin.rpc.invoice(int(amount) * 1000, label, description)
         b11 = invoice["bolt11"]
         qr = make_base64_qr_code(b11)
@@ -84,7 +84,7 @@ def donation_form():
     invoices = plugin.rpc.listinvoices()["invoices"]
     donations = []
     for invoice in invoices:
-        if invoice["label"].startswith("ln-plugin-donation-"):
+        if invoice["label"].startswith("ln-plugin-donations-"):
             # FIXME: change to paid after debugging
             if invoice["status"] == "paid":
                 bolt11 = plugin.rpc.decodepay(invoice["bolt11"])
@@ -159,7 +159,7 @@ def donationserver(command="start", port=8088):
     try:
         port = int(port)
     except Exception:
-        port = int(plugin.options['donation-web-port']['value'])
+        port = int(plugin.options['donations-web-port']['value'])
 
     if command == "list":
         return "servers running on the following ports: {}".format(list(jobs.keys()))
@@ -189,13 +189,13 @@ def donationserver(command="start", port=8088):
 
 
 plugin.add_option(
-    'donation-autostart',
+    'donations-autostart',
     'true',
     'Should the donation server start automatically'
 )
 
 plugin.add_option(
-    'donation-web-port',
+    'donations-web-port',
     '8088',
     'Which port should the donation server listen to?'
 )
@@ -203,9 +203,9 @@ plugin.add_option(
 
 @plugin.init()
 def init(options, configuration, plugin):
-    port = int(options['donation-web-port'])
+    port = int(options['donations-web-port'])
 
-    if options['donation-autostart'].lower() in ['true', '1']:
+    if options['donations-autostart'].lower() in ['true', '1']:
         start_server(port)
 
 

--- a/donations/donations.py
+++ b/donations/donations.py
@@ -139,7 +139,7 @@ def stop_server(port):
 
 
 @plugin.method('donationserver')
-def donationserver(request, command="start", port=8088):
+def donationserver(command="start", port=8088):
     """Starts a donationserver with {start/stop/restart} on {port}.
 
     A Simple HTTP Server is created that can serve a donation webpage and
@@ -177,7 +177,7 @@ def donationserver(request, command="start", port=8088):
         if stop_server(port):
             return "stopped server on port {}".format(port)
         else:
-            return "could not stop the server"
+            return "could not stop the server on port {}".format(port)
 
     if command == "restart":
         stop_server(port)

--- a/donations/test_donations.py
+++ b/donations/test_donations.py
@@ -25,5 +25,5 @@ def test_donation_server(node_factory):
     port = reserve()
     l1.rpc.donationserver('start', port)
     l1.daemon.wait_for_logs('plugin-donations.py: Process server on port')
-    msg = l1.rpc.donationserver("stop")
+    msg = l1.rpc.donationserver("stop", port)
     assert msg.startswith(f'stopped server on port')

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -31,7 +31,12 @@ def monitor(plugin):
     chans = {}
     states = {}
     for p in peers['peers']:
-        for c in p['channels']:
+        channels = []
+        if 'channels' in p:
+            channels = p['channels']
+        elif 'num_channels' in p and p['num_channels'] > 0:
+            channels = plugin.rpc.listpeerchannels(p['id'])['channels']
+        for c in channels:
             if p['connected']:
                 reply['num_connected'] += 1
             reply['num_channels'] += 1

--- a/rebalance/test_rebalance.py
+++ b/rebalance/test_rebalance.py
@@ -64,8 +64,8 @@ def test_rebalance_manual(node_factory, bitcoind):
     wait_for_all_htlcs(nodes)
 
     # check that channels are now balanced
-    c12 = l1.rpc.listpeers(l2.info['id'])['peers'][0]['channels'][0]
-    c13 = l1.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
+    c12 = l1.rpc.listpeerchannels(l2.info['id'])['channels'][0]
+    c13 = l1.rpc.listpeerchannels(l3.info['id'])['channels'][0]
     assert abs(0.5 - (Millisatoshi(c12['to_us_msat']) / Millisatoshi(c12['total_msat']))) < 0.01
     assert abs(0.5 - (Millisatoshi(c13['to_us_msat']) / Millisatoshi(c13['total_msat']))) < 0.01
 
@@ -136,8 +136,8 @@ def test_rebalance_all(node_factory, bitcoind):
     wait_for_all_htlcs(nodes)
 
     # check that channels are now balanced
-    c12 = l1.rpc.listpeers(l2.info['id'])['peers'][0]['channels'][0]
-    c13 = l1.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
+    c12 = l1.rpc.listpeerchannels(l2.info['id'])['channels'][0]
+    c13 = l1.rpc.listpeerchannels(l3.info['id'])['channels'][0]
     assert abs(0.5 - (Millisatoshi(c12['to_us_msat']) / Millisatoshi(c12['total_msat']))) < 0.01
     assert abs(0.5 - (Millisatoshi(c13['to_us_msat']) / Millisatoshi(c13['total_msat']))) < 0.01
 

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -100,7 +100,7 @@ def summary(plugin, exclude=''):
     reply = {}
     info = plugin.rpc.getinfo()
     funds = plugin.rpc.listfunds()
-    peers = plugin.rpc.listpeers()
+    peers = plugin.rpc.listpeers()['peers']
 
     # Make it stand out if we're not on mainnet.
     if info['network'] != 'bitcoin':
@@ -123,11 +123,16 @@ def summary(plugin, exclude=''):
     reply['num_channels'] = 0
     reply['num_connected'] = 0
     reply['num_gossipers'] = 0
-    for p in peers['peers']:
+    for p in peers:
         pid = p['id']
+        channels = []
+        if 'channels' in p:
+            channels = p['channels']
+        elif 'num_channels' in p and p['num_channels'] > 0:
+            channels = plugin.rpc.listpeerchannels(pid)['channels']
         addpeer(plugin, p)
         active_channel = False
-        for c in p['channels']:
+        for c in channels:
             if c['state'] != 'CHANNELD_NORMAL':
                 continue
             active_channel = True


### PR DESCRIPTION
Recent upstream on cli have seperated `listpeers` and `listpeerchannels` output. This is in deprecation cycle, but CI tests already fail, because they run on `DEPRECATED_APIS=0`.

Affected plugins:
 - helpme
 - jitrebalance
 - monitor
 - drain
 - rebalance
 - summary
 - donations (other issues)