### PR TITLE
currencyrate: fix usage type

### DIFF
--- a/currencyrate/README.md
+++ b/currencyrate/README.md
@@ -22,10 +22,10 @@ options multiple times to add or disable multiple sources.
 
 ## Commands
 
-`currencyrate` returns the number of msats per unit from every backend, eg:
+`currencyrates` returns the number of msats per unit from every backend, eg:
 
 ```
-$ lightning-cli currencyrate USD
+$ lightning-cli currencyrates USD
 {
    "localbitcoins": "5347227msat",
    "bitstamp": "5577515msat",


### PR DESCRIPTION
The actual rate command is `currencyrates` (plural!). I just fixed the README.md, however it would be better to have the plugins name `currencyrate` aligned with its main method to circumvent users having issues trying around with a new plugin.

@rusty: maybe we add a method `currencyrate` (w/o plural) that simply calls `currencyrates`...