### PR TITLE
Update requirements.txt

### DIFF
--- a/sauron/requirements.txt
+++ b/sauron/requirements.txt
@@ -1,2 +1,2 @@
-pyln-client>=0.7.3
+pyln-client>=23.2
 requests[socks]>=2.23.0


### PR DESCRIPTION
The old `pyln-client` here is causing this output on CLN v23.02: `UNUSUAL plugin-sauron.py: ValueError: Non-integer request id \"cln:getchaininfo#24\"`

Updating `pyln-client` to `23.2` fixes for me.