### PR TITLE
prom: Add base and proportional fee to the channel metric.

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -126,6 +126,16 @@ class ChannelsCollector(BaseLnCollector):
             'How many HTLCs are currently active on this channel?',
             labels=['id', 'scid', 'alias'],
         )
+        fee_base_msat_gauge = GaugeMetricFamily(
+            'lightning_channel_fee_base_msat',
+            'How many msats do we charge as a base fee for routing?',
+            labels=['id', 'scid', 'alias'],
+        )
+        fee_proportional_millionths_gauge = GaugeMetricFamily(
+            'lightning_channel_fee_proportional_millionths',
+            'How many millionths of the forwarded amount do we charge for routing?',
+            labels=['id', 'scid', 'alias'],
+        )
 
         # Incoming routing statistics
         in_payments_offered_gauge = GaugeMetricFamily(
@@ -186,6 +196,8 @@ class ChannelsCollector(BaseLnCollector):
                                        c['spendable_msat'].to_satoshi())
             total_gauge.add_metric(labels, c['total_msat'].to_satoshi())
             htlc_gauge.add_metric(labels, len(c['htlcs']))
+            fee_base_msat_gauge.add_metric(labels, int(c['fee_base_msat']))
+            fee_proportional_millionths_gauge.add_metric(labels, int(c['fee_proportional_millionths']))
 
             in_payments_offered_gauge.add_metric(labels, c['in_payments_offered'])
             in_payments_fulfilled_gauge.add_metric(labels, c['in_payments_fulfilled'])
@@ -202,6 +214,8 @@ class ChannelsCollector(BaseLnCollector):
             total_gauge,
             spendable_gauge,
             balance_gauge,
+            fee_base_msat_gauge,
+            fee_proportional_millionths_gauge,
             in_payments_offered_gauge,
             in_payments_fulfilled_gauge,
             in_msatoshi_offered_gauge,


### PR DESCRIPTION
Closes https://github.com/lightningd/plugins/issues/398

This PR adds the requested channel metrics:

```
# HELP lightning_channel_fee_base_msat How many msats do we charge as a base fee for routing?
# TYPE lightning_channel_fee_base_msat gauge
lightning_channel_fee_base_msat{alias="deezy.io ⚡✨",id="024bfaf0cabe7f874fd33ebf7c6f4e5385971fc504ef3f492432e9e3ec77e1b5cf",scid="792604x1216x0"} 1000.0
# HELP lightning_channel_fee_proportional_millionths How many millionths of the forwarded amount do we charge for routing?
# TYPE lightning_channel_fee_proportional_millionths gauge
lightning_channel_fee_proportional_millionths{alias="deezy.io ⚡✨",id="024bfaf0cabe7f874fd33ebf7c6f4e5385971fc504ef3f492432e9e3ec77e1b5cf",scid="792604x1216x0"} 10.0
# HELP lightning_channel_in_payments_offered How many incoming payments did we try to forward?
```

Not actually sure if this change is actually warranted or not, but it seems reasonable to me.