### PR TITLE
Prometheus metric names

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -50,12 +50,12 @@ class FundsCollector(BaseLnCollector):
         channel_funds = sum(
             [c['our_amount_msat'].to_satoshi() for c in funds['channels']]
         )
-        total = output_funds + channel_funds
+        funds_sum = output_funds + channel_funds
 
         yield GaugeMetricFamily(
-            'lightning_funds_total',
-            "Total satoshis we own on this node.",
-            value=total,
+            'lightning_funds_sum',
+            "The sum total of satoshis we currently own on this node.",
+            value=funds_sum,
         )
         yield GaugeMetricFamily(
             'lightning_funds_output',

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -76,12 +76,12 @@ class PeerCollector(BaseLnCollector):
         connected = GaugeMetricFamily(
             'lightning_peer_connected',
             'Is the peer currently connected?',
-            labels=['id'],
+            labels=['peer_id'],
         )
         count = GaugeMetricFamily(
             'lightning_peer_channels',
             "The number of channels with the peer",
-            labels=['id'],
+            labels=['peer_id'],
         )
 
         for p in peers:
@@ -97,66 +97,66 @@ class ChannelsCollector(BaseLnCollector):
         balance_gauge = GaugeMetricFamily(
             'lightning_channel_balance',
             'How many funds are at our disposal?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         spendable_gauge = GaugeMetricFamily(
             'lightning_channel_spendable',
             'How much can we currently send over this channel?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         total_gauge = GaugeMetricFamily(
             'lightning_channel_capacity',
             'How many funds are in this channel in total?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         htlc_gauge = GaugeMetricFamily(
             'lightning_channel_htlcs',
             'How many HTLCs are currently active on this channel?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
 
         # Incoming routing statistics
         in_payments_offered_gauge = GaugeMetricFamily(
             'lightning_channel_in_payments_offered',
             'How many incoming payments did we try to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         in_payments_fulfilled_gauge = GaugeMetricFamily(
             'lightning_channel_in_payments_fulfilled',
             'How many incoming payments did we succeed to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         in_msatoshi_offered_gauge = GaugeMetricFamily(
             'lightning_channel_in_msatoshi_offered',
             'How many incoming msats did we try to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         in_msatoshi_fulfilled_gauge = GaugeMetricFamily(
             'lightning_channel_in_msatoshi_fulfilled',
             'How many incoming msats did we succeed to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
 
         # Outgoing routing statistics
         out_payments_offered_gauge = GaugeMetricFamily(
             'lightning_channel_out_payments_offered',
             'How many outgoing payments did we try to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         out_payments_fulfilled_gauge = GaugeMetricFamily(
             'lightning_channel_out_payments_fulfilled',
             'How many outgoing payments did we succeed to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         out_msatoshi_offered_gauge = GaugeMetricFamily(
             'lightning_channel_out_msatoshi_offered',
             'How many outgoing msats did we try to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
         out_msatoshi_fulfilled_gauge = GaugeMetricFamily(
             'lightning_channel_out_msatoshi_fulfilled',
             'How many outgoing msats did we succeed to forward?',
-            labels=['id', 'scid', 'alias'],
+            labels=['peer_id', 'scid', 'alias'],
         )
 
         peers = self.rpc.listpeers()['peers']

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -54,7 +54,7 @@ class FundsCollector(BaseLnCollector):
 
         yield GaugeMetricFamily(
             'lightning_funds_sum',
-            "The sum total of satoshis we currently own on this node.",
+            "The sum of satoshis we currently own on this node.",
             value=funds_sum,
         )
         yield GaugeMetricFamily(


### PR DESCRIPTION
This is a highly disruptive change, and may not be worthwhile at this point.

Closes https://github.com/lightningd/plugins/issues/143

- [x] rename id to peer_id
- [x] rename "total" to "sum"

And change msats to sats for consistency: 
- [ ] in_payments_offered
- [ ] in_payments_fulfilled
- [ ] in_msatoshi_offered
- [ ] in_msatoshi_fulfilled

Also this PR is a draft because if I make the other changes, then I will first need to learn how to make PRs depend on eachother (or something). 