### PR TITLE
feeadjuster: basefee switch

### DIFF
--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -329,8 +329,14 @@ def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
     plugin.fee_strategy = fee_strategy_switch.get(options.get("feeadjuster-feestrategy"), get_fees_global)
     plugin.median_multiplier = float(options.get("feeadjuster-median-multiplier"))
     config = plugin.rpc.listconfigs()
-    plugin.adj_basefee = config["fee-base"]
-    plugin.adj_ppmfee = config["fee-per-satoshi"]
+    if "fee-base" in config:
+        plugin.adj_basefee = config["fee-base"]
+    else:
+        plugin.adj_basefee = 1000
+    if "fee-per-satoshi" in config:
+        plugin.adj_ppmfee = config["fee-per-satoshi"]
+    else:
+        plugin.adj_ppmfee = 10
 
     # normalize the imbalance percentage value to 0%-50%
     if plugin.imbalance < 0 or plugin.imbalance > 1:

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -22,6 +22,17 @@ plugin.mutex = Lock()
 plugin.mutex.acquire()
 
 
+def read_excludelist():
+    try:
+        with open('feeadjuster-exclude.list') as file:
+            exclude_list = [l.rstrip("\n") for l in file]
+            print("Excluding the channels with the nodes:", exclude_list)
+    except FileNotFoundError:
+        exclude_list = []
+        print("There is no feeadjuster-exclude.list given, applying the options to the channels with all peers.")
+    return exclude_list
+
+
 def get_adjusted_percentage(plugin: Plugin, scid: str):
     """
     For big channels, there may be a wide range where the liquidity is just okay.
@@ -262,13 +273,8 @@ def feeadjust(plugin: Plugin, scid: str = None):
     if plugin.fee_strategy == get_fees_median and not plugin.listchannels_by_dst:
         plugin.channels = plugin.rpc.listchannels()['channels']
     channels_adjusted = 0
-    try:
-        with open('feeadjuster-exclude.list') as file:
-            exclude_list = [l.rstrip("\n") for l in file]
-            print("Excluding the channels with the nodes:", exclude_list)
-    except FileNotFoundError:
-        exclude_list = []
-        print("There is no feeadjuster-exclude.list given, applying the options to the channels with all peers.")
+    exclude_list = read_excludelist()
+
     for chan in plugin.peerchannels:
         if chan["peer_id"] in exclude_list:
             continue

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -265,8 +265,9 @@ def feeadjust(plugin: Plugin, scid: str = None):
     This method is automatically called in plugin init, or can be called manually after a successful payment.
     Otherwise, the plugin keeps the fees up-to-date.
 
-    To stop setting the channels with a list of nodes place a file called `feeadjuster-exclude.list` in the
-    lightningd data directory with a simple line-by-line list of pubkeys.
+    To stop adjusting the channels for a set PeerIDs or SCIDs, place a file
+    called `feeadjuster-exclude.list` in the lightningd data directory with a
+    simple line-by-line list of PeerIDs (pubkeys) or SCIDs.
     """
     plugin.mutex.acquire(blocking=True)
     plugin.peerchannels = get_peerchannels(plugin)
@@ -276,7 +277,7 @@ def feeadjust(plugin: Plugin, scid: str = None):
     exclude_list = read_excludelist()
 
     for chan in plugin.peerchannels:
-        if chan["peer_id"] in exclude_list:
+        if scid in exclude_list or chan["peer_id"] in exclude_list:
             continue
         if chan["state"] == "CHANNELD_NORMAL":
             _scid = chan.get("short_channel_id")

--- a/feeadjuster/test_feeadjuster.py
+++ b/feeadjuster/test_feeadjuster.py
@@ -314,7 +314,8 @@ def test_feeadjuster_median(node_factory):
         "plugin": plugin_path,
         "feeadjuster-deactivate-fuzz": None,
         "feeadjuster-imbalance": 0.5,
-        "feeadjuster-feestrategy": "median"
+        "feeadjuster-feestrategy": "median",
+        "feeadjuster-basefee": True,
     }
     l1, l2, l3, _ = node_factory.line_graph(4, opts=[opts, l2_opts, opts, opts],
                                             wait_for_announce=True)


### PR DESCRIPTION
- make dynamic adjustments of the base fee optional and off per default.
Currently only affects median strategy

- fixes some bugs, breakages and testcases along the way