### PR TITLE
Removing commando from archived plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,6 @@ Python plugins developers must ensure their plugin to work with all Python versi
  - [C# Plugin Guideline and example project][csharp-example] by @joemphilips
  - [Kotlin plugin guideline and example][kotlin-example] by @vincenzopalazzo
 
-## Archived plugins
-
-The following is a list of archived plugins that no longer maintained.
-If you like a plugin from that list, feel free to update and fix it, so we can
-un-archive it.
-
-| Name                                 | Short description                                                                           |
-| ------------------------------------ | ------------------------------------------------------------------------------------------- |
-| [commando][commando]                 | Authorize peers to run commands on your node, and running commands on them.                 |
-
 [esplora]: https://github.com/Blockstream/esplora
 [pers-chans]: https://github.com/lightningd/plugins/tree/master/persistent-channels
 [probe]: https://github.com/lightningd/plugins/tree/master/probe
@@ -235,7 +225,6 @@ un-archive it.
 [java-api]: https://github.com/clightning4j/JRPClightning
 [btcli4j]: https://github.com/clightning4j/btcli4j
 [backup]: https://github.com/lightningd/plugins/tree/master/backup
-[commando]: https://github.com/lightningd/plugins/tree/master/archive/commando
 [reporter]: https://github.com/LNOpenMetrics/go-lnmetrics.reporter
 [csharp-example]: https://github.com/joemphilips/DotNetLightning/tree/master/examples/HelloWorldPlugin
 [kotlin-example]: https://vincenzopalazzo.medium.com/a-day-in-a-c-lightning-plugin-with-koltin-c8bbd4fa0406

--- a/archive/commando/README.md
+++ b/archive/commando/README.md
@@ -1,5 +1,18 @@
 # Commando plugin
 
+Commando has been **included in Core Lightning as first class C plugin**.
+
+It has been actively developed since and has more cool new features added
+than listed below.
+
+Checkout latest updates on commando at:
+https://docs.corelightning.org/docs/commando &
+https://docs.corelightning.org/reference/lightning-commando
+
+------------------------------------------------------------------------------------------------------
+
+# Archived Commando python plugin
+
 This plugin allows other nodes to send your node commands, and allows you
 to send them to other nodes.  The nodes must be authorized, and must be
 directly connected.


### PR DESCRIPTION
- Remove Archived list from Readme
- Updated archived commando python plugin Readme