### PR TITLE
Checkout submodules for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Checkout c-lightning@${{ matrix.cln-version }}
       uses: actions/checkout@v4


### PR DESCRIPTION
based on https://github.com/lightningd/plugins/pull/484

Plugins in submodules will get checked out, so they can get tested.