### PR TITLE
github: fix workflow badge on readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Community curated plugins for Core-Lightning.
 
-![Integration Tests](https://github.com/lightningd/plugins/workflows/Integration%20Tests/badge.svg)
+![Integration Tests](https://github.com/lightningd/plugins/actions/workflows/main.yml/badge.svg)
 
 ## Available plugins
 


### PR DESCRIPTION
The old badge was pointing to the workflows name
https://github.com/lightningd/plugins/workflows/Integration%20Tests/badge.svg

However this seems to be always failing. Pointing to the workflow file main.yml, which only contains the one integration test workflow, gives a now green badge.

I'm not totally into the github internals, so maybe I'm mistaken on this one. Feedback appreciated.