### PR TITLE
Generic plugin support

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -200,7 +200,7 @@ def prepare_generic(p: Plugin, directory: Path):
     if p.details['setup'].exists():
         print(f"Running setup script from {p.details['setup']}")
         subprocess.check_call(
-            ['bash',  p.details['setup']],
+            ['bash',  p.details['setup'], f'TEST_DIR={directory}'],
             stderr=subprocess.STDOUT,
         )
     install_pyln_testing(pip_path)


### PR DESCRIPTION
I've thought more about https://github.com/lightningd/plugins/pull/487 and since CLN supports basically any language for plugins  i propose to take this generic approach instead.
Non-python plugins put their `requirements.txt` and `setup.sh` in the `tests` folder (the one we already search for executing tests). The bash script will allow python developer to setup the plugin environment as they see fit.

Example [setup.sh](https://github.com/daywalker90/summars/blob/bash-test-setup/tests/setup.sh) from my summars plugin and then a simple switch in my [utils.py](https://github.com/daywalker90/summars/blob/5068ba0a5420be2c9f1147cb824819ea7a89e545/tests/util.py#L15) for local dev and CI