### PR TITLE
Pin poetry to 1.7.1 to fix tests for poetry-based plugins

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -120,7 +120,7 @@ def prepare_env_poetry(p: Plugin, directory: Path) -> bool:
     subprocess.check_call(['which', 'python3'])
 
     subprocess.check_call([
-        pip3, 'install', '-U', *pip_opts, 'pip', 'wheel', 'poetry'
+        pip3, 'install', '-U', *pip_opts, 'pip', 'wheel', 'poetry==1.7.1'
     ], cwd=p.path.parent)
 
     # Install pytest (eventually we'd want plugin authors to include


### PR DESCRIPTION
This PR is a temporary fix for the poetry-based backup and donations plugins whose tests are currently failing in CI. Recently released poetry v1.8 seems to cause problems in the current test setup. Pinning poetry to v1.7.1 makes the tests pass again.