### PR TITLE
CI: Fix workflow 'main' for pull requests with head repository's branch set to 'master'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,19 +96,25 @@ jobs:
 
         plugin_dirs=''
 
-        if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+        if [[ '${{ github.event_name }}' == 'pull_request' ]]
+        then
           # Fetch and checkout branches to permit the 'git diff' below.
           git fetch && git checkout ${{ github.base_ref }}
 
+          head_ref='${{ github.head_ref }}'
           source_repo="${{ github.event.pull_request.head.repo.full_name }}"
           # Fetch and update local head ref if the source repository is not ours.
-          if [[ $source_repo != ${{ github.repository }} ]]; then
-            git fetch https://github.com/$source_repo.git ${{ github.head_ref }}:${{ github.head_ref }}
+          if [[ "$source_repo" != "${{ github.repository }}" ]]
+          then
+            git remote add other-remote https://github.com/$source_repo
+            git fetch other-remote
+            head_ref="other-remote/${{ github.head_ref }}"
+          else
+            git checkout ${{ github.head_ref }}
           fi
-          git checkout ${{ github.head_ref }}
 
           # Collect the plugins that have changed.
-          plugin_dirs=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} \
+          plugin_dirs=$(git diff --name-only ${{ github.base_ref }} $head_ref \
             | cut -d '/' -f1 \
             | grep -v '^\.' \
             | grep -v 'archived' \


### PR DESCRIPTION
This PR resolves an issue from the latest update to workflow `main`. The workflow currently fails with the error below if it was triggered by a pull request and the head repository's branch is set to `master`.
```
fatal: refusing to fetch into branch 'refs/heads/master' checked out at '/home/runner/work/plugins/plugins'
Error: Process completed with exit code [128](https://github.com/lightningd/plugins/actions/runs/8113474790/job/22176862883#step:8:129). 
```