### PR TITLE
CI: Add two columns for the main and nightly workflows to the "Available plugins" table in README.md

### DIFF
--- a/.ci/update_badges.py
+++ b/.ci/update_badges.py
@@ -1,0 +1,168 @@
+import json
+import os
+import subprocess
+from collections import namedtuple
+from pathlib import Path, PosixPath
+from typing import Generator, List
+
+Plugin = namedtuple(
+    "Plugin",
+    [
+        "name",
+        "path",
+        "language",
+        "framework",
+        "details",
+    ],
+)
+
+exclude = [
+    ".ci",
+    ".git",
+    ".github",
+    "archived",
+    "lightning",
+]
+
+
+def configure_git():
+    # Git needs some user and email to be configured in order to work in the context of GitHub Actions.
+    subprocess.run(
+        ["git", "config", "--global", "user.email", '"lightningd@github.plugins.repo"']
+    )
+    subprocess.run(["git", "config", "--global", "user.name", '"lightningd"'])
+
+
+def get_testfiles(p: Plugin) -> List[PosixPath]:
+    return [
+        x
+        for x in p.path.iterdir()
+        if (x.is_dir() and x.name == "tests")
+        or (x.name.startswith("test_") and x.name.endswith(".py"))
+    ]
+
+
+def has_testfiles(p: Plugin) -> bool:
+    return len(get_testfiles(p)) > 0
+
+
+def list_plugins(plugins):
+    return ", ".join([p.name for p in sorted(plugins)])
+
+
+def enumerate_plugins(basedir: Path) -> Generator[Plugin, None, None]:
+    plugins = list(
+        [x for x in basedir.iterdir() if x.is_dir() and x.name not in exclude]
+    )
+    pip_pytest = [x for x in plugins if (x / Path("requirements.txt")).exists()]
+    print(f"Pip plugins: {list_plugins(pip_pytest)}")
+
+    poetry_pytest = [x for x in plugins if (x / Path("pyproject.toml")).exists()]
+    print(f"Poetry plugins: {list_plugins(poetry_pytest)}")
+
+    other_plugins = [
+        x for x in plugins if x not in pip_pytest and x not in poetry_pytest
+    ]
+    print(f"Other plugins: {list_plugins(other_plugins)}")
+
+    for p in sorted(pip_pytest):
+        yield Plugin(
+            name=p.name,
+            path=p,
+            language="python",
+            framework="pip",
+            details={
+                "requirements": p / Path("requirements.txt"),
+                "devrequirements": p / Path("requirements-dev.txt"),
+            },
+        )
+
+    for p in sorted(poetry_pytest):
+        yield Plugin(
+            name=p.name,
+            path=p,
+            language="python",
+            framework="poetry",
+            details={
+                "pyproject": p / Path("pyproject.toml"),
+            },
+        )
+
+    for p in sorted(other_plugins):
+        yield Plugin(
+            name=p.name,
+            path=p,
+            language="other",
+            framework="generic",
+            details={
+                "requirements": p / Path("tests/requirements.txt"),
+                "setup": p / Path("tests/setup.sh"),
+            },
+        )
+
+
+def update_and_commit_badge(plugin_name, passed, workflow):
+    json_data = { "schemaVersion": 1, "label": "", "message": " ✔ ", "color": "green" }
+    if not passed:
+        json_data.update({"message": "✗", "color": "red"})
+
+    filename = os.path.join(".badges", f"{plugin_name}_{workflow}.json")
+    with open(filename, "w") as file:
+        file.write(json.dumps(json_data))
+
+    output = subprocess.check_output(["git", "add", "-v", filename]).decode("utf-8")
+    if output != "":
+        subprocess.run(["git", "commit", "-m", f'Update {plugin_name} badge to {"passed" if passed else "failed"} ({workflow})'])
+        return True
+    return False
+
+
+def push_badges_data(workflow, num_of_python_versions):
+    print("Pushing badges data...")
+    configure_git()
+    subprocess.run(["git", "fetch"])
+    subprocess.run(["git", "checkout", "badges"])
+    subprocess.run(["git", "pull"])
+
+    root_path = (
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+        .decode("ASCII")
+        .strip()
+    )
+    plugins = list(enumerate_plugins(Path(root_path)))
+
+    any_changes = False
+    for plugin in plugins:
+        results = []
+        _dir = f".badges/gather_data/main/{plugin.name}"
+        if os.path.exists(_dir):
+            for child in Path(_dir).iterdir():
+                result = child.read_text().strip()
+                results.append(result)
+                print(f"Results for {child}: {result}")
+
+            passed = False
+            if (
+                len(set(results)) == 1
+                and results[0] == "passed"
+                # and len(results) == num_of_python_versions  # TODO: Disabled as gather data for python versions is missing sporadingly.
+            ):
+                passed = True
+            any_changes |= update_and_commit_badge(plugin.name, passed, workflow)
+
+    if any_changes:
+        subprocess.run(["git", "push", "origin", "badges"])
+    print("Done.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Plugins completion script")
+    parser.add_argument("workflow", type=str, help="Name of the GitHub workflow")
+    parser.add_argument(
+        "num_of_python_versions", type=str, help="Number of Python versions"
+    )
+    args = parser.parse_args()
+
+    push_badges_data(args.workflow, int(args.num_of_python_versions))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Run pytest tests
+      id: pytest_tests
       run: |
         export CLN_PATH=${{ github.workspace }}/lightning
         export COMPAT=${{ matrix.deprecated }}
@@ -98,17 +99,32 @@ jobs:
 
         # Run the tests: In the case of a 'pull_request' event only the plugins in `plugin_dirs`
         # are going to be tested; otherwise ('push' event) we test all plugins.
-        python3 .ci/test.py $(echo "$plugin_dirs")
+
+        update_badges=''
+        if [[ "${{ github.event_name }}" == 'push' && "${{ github.ref }}" == 'refs/heads/master' ]] || [[ "${{ github.event_name }}" == 'schedule' ]]
+        then
+            update_badges='--update-badges'
+        fi
+
+        python3 .ci/test.py main ${{ matrix.python-version }} $update_badges $(echo "$plugin_dirs")
 
   gather:
-    # A dummy task that depends on the full matrix of tests, and
-    # signals successful completion. Used for the PR status to pass
-    # before merging.
+    # A dummy task that depends on the full matrix of tests, and signals completion.
     name: CI completion
     runs-on: ubuntu-22.04
+    if: ${{ always() }}
     needs:
       - build-and-test
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Complete
         run: |
-          echo CI completed successfully
+          echo "Updating badges data..."
+          python3 .ci/update_badges.py main 5  # We test for 5 distinct Python versions
+          echo "CI completed"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,17 +91,25 @@ jobs:
         export CLN_PATH=${{ github.workspace }}/lightning
         pip3 install --upgrade pip
         pip3 install --user -U virtualenv pip > /dev/null
-        python3 .ci/test.py
+        python3 .ci/test.py nightly --update-badges
 
   gather:
-    # A dummy task that depends on the full matrix of tests, and
-    # signals successful completion. Used for the PR status to pass
-    # before merging.
+    # A dummy task that depends on the full matrix of tests, and signals completion.
     name: CI completion
     runs-on: ubuntu-22.04
+    if: ${{ always() }}
     needs:
       - nightly-build-and-test
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Complete
         run: |
-          echo Nightly CI completed successfully
+          echo "Updating badges data..."
+          python3 .ci/update_badges.py main 5  # We test for 5 distinct Python versions
+          echo "CI completed"

--- a/README.md
+++ b/README.md
@@ -2,45 +2,46 @@
 
 Community curated plugins for Core-Lightning.
 
-![Integration Tests (latest)](https://github.com/lightningd/plugins/actions/workflows/main.yml/badge.svg)
-![Nightly Integration Tests (master)](https://github.com/lightningd/plugins/actions/workflows/nightly.yml/badge.svg)
+[![Integration Tests (latest)](https://github.com/lightningd/plugins/actions/workflows/main.yml/badge.svg)](https://github.com/lightningd/plugins/actions/workflows/main.yml)
+[![Nightly Integration Tests (master)](https://github.com/lightningd/plugins/actions/workflows/nightly.yml/badge.svg)](https://github.com/lightningd/plugins/actions/workflows/nightly.yml)
 
 ## Available plugins
 
-| Name                                 | Short description                                                                           |
-| ------------------------------------ | ------------------------------------------------------------------------------------------- |
-| [backup][backup]                     | A simple and reliable backup plugin                                                         |
-| [btcli4j][btcli4j]                   | A Bitcoin Backend to enable safely the pruning mode, and support also rest APIs.            |
-| [circular][circular]                 | A smart rebalancing plugin for Core Lightning routing nodes                                 |
-| [clearnet][clearnet]                 | A plugin that can be used to enforce clearnet connections when possible                     |
-| [cln-ntfy][cln-ntfy]                 | Core Lightning plugin for sending `ntfy` alerts.                                            |
-| [currencyrate][currencyrate]         | A plugin to convert other currencies to BTC using web requests                              |
-| [donations][donations]               | A simple donations page to accept donations from the web                                    |
-| [event-websocket][event-websocket]   | Exposes notifications over a Websocket                                                      |
-| [feeadjuster][feeadjuster]           | Dynamic fees to keep your channels more balanced                                            |
-| [go-lnmetrics.reporter][reporter]    | Collect and report of the lightning node metrics                                            |
-| [graphql][graphql]                   | Exposes the Core-Lightning API over [graphql][graphql-spec]                                 |
-| [holdinvoice][holdinvoice]           | Holds htlcs for invoices until settle or cancel is called (aka Hodlinvoices) via RPC/GRPC   |
-| [invoice-queue][invoice-queue]       | Listen to lightning invoices from multiple nodes and send to a redis queue for processing   |
-| [lightning-qt][lightning-qt]         | A bitcoin-qt-like GUI for lightningd                                                        |
-| [listmempoolfunds][listmempoolfunds] | Track unconfirmed wallet deposits                                                           |
-| [monitor][monitor]                   | helps you analyze the health of your peers and channels                                     |
-| [nloop][nloop]                       | Generic Lightning Loop for boltz                                                            |
-| [paythrough][paythrough]             | Pay an invoice through a specific channel, regardless of better routes                      |
-| [persistent-channels][pers-chans]    | Maintains a number of channels to peers                                                     |
-| [poncho][poncho]                     | Turns CLN into a [hosted channels][blip12] provider                                         |
-| [pruning][pruning]                   | This plugin manages pruning of bitcoind such that it can always sync                        |
-| [rebalance][rebalance]               | Keeps your channels balanced                                                                |
-| [reckless][reckless]                 | An **experimental** plugin manager (search/install plugins)                                 |
-| [sauron][sauron]                     | A Bitcoin backend relying on [Esplora][esplora]'s API                                       |
-| [sitzprobe][sitzprobe]               | A Lightning Network payment rehearsal utility                                               |
-| [sling][sling]                       | Rebalance your channels with smart rules and built-in background tasks                      |
-| [sparko][sparko]                     | RPC over HTTP with fine-grained permissions, SSE and spark-wallet support                   |
-| [summars][summars]                   | Print configurable summary of node, channels and optionally forwards, invoices, payments    |
-| [trustedcoin][trustedcoin]           | Replace your Bitcoin Core with data from public block explorers                             |
-| [watchtower-client][watchtower-client]      | Watchtower client for The Eye of Satoshi                                                    |
-| [webhook][webhook]                   | Dispatches webhooks based from [event notifications][event-notifications]                   |
-| [zmq][zmq]                           | Publishes notifications via [ZeroMQ][zmq-home] to configured endpoints                      |
+| Name                                 | Short description                                                                           | CLN<br>![GitHub Release](https://img.shields.io/github/v/release/ElementsProject/lightning?label=%20&color=393D47) | CLN<br>![Static Badge](https://img.shields.io/badge/master-master?color=393D47) |
+| ------------------------------------ | ------------------------------------------------------------------------------------------- | :----: | :-----: |
+| [backup][backup]                     | A simple and reliable backup plugin                                                         | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fbackup_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fbackup_nightly.json) |
+| [btcli4j][btcli4j]                   | A Bitcoin Backend to enable safely the pruning mode, and support also rest APIs.            |        |         |
+| [circular][circular]                 | A smart rebalancing plugin for Core Lightning routing nodes                                 |        |         |
+| [clearnet][clearnet]                 | A plugin that can be used to enforce clearnet connections when possible                     | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fclearnet_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fclearnet_nightly.json) |
+| [cln-ntfy][cln-ntfy]                 | Core Lightning plugin for sending `ntfy` alerts.                                            |        |         |
+| [currencyrate][currencyrate]         | A plugin to convert other currencies to BTC using web requests                              |        |         |
+| [datastore][datastore]               | The Datastore Plugin                                                                        | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fdatastore_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fdatastore_nightly.json) |
+| [donations][donations]               | A simple donations page to accept donations from the web                                    | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fdonations_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fdonations_nightly.json) |
+| [event-websocket][event-websocket]   | Exposes notifications over a Websocket                                                      |        |         |
+| [feeadjuster][feeadjuster]           | Dynamic fees to keep your channels more balanced                                            | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Ffeeadjuster_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Ffeeadjuster_nightly.json) |
+| [go-lnmetrics.reporter][reporter]    | Collect and report of the lightning node metrics                                            |        |         |
+| [graphql][graphql]                   | Exposes the Core-Lightning API over [graphql][graphql-spec]                                 |        |         |
+| [holdinvoice][holdinvoice]           | Holds htlcs for invoices until settle or cancel is called (aka Hodlinvoices) via RPC/GRPC   | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fholdinvoice_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fholdinvoice_nightly.json) |
+| [invoice-queue][invoice-queue]       | Listen to lightning invoices from multiple nodes and send to a redis queue for processing   |        |         |
+| [lightning-qt][lightning-qt]         | A bitcoin-qt-like GUI for lightningd                                                        |        |         |
+| [listmempoolfunds][listmempoolfunds] | Track unconfirmed wallet deposits                                                           |        |         |
+| [monitor][monitor]                   | helps you analyze the health of your peers and channels                                     | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fmonitor_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fmonitor_nightly.json) |
+| [nloop][nloop]                       | Generic Lightning Loop for boltz                                                            |        |         |
+| [paythrough][paythrough]             | Pay an invoice through a specific channel, regardless of better routes                      |        |         |
+| [persistent-channels][pers-chans]    | Maintains a number of channels to peers                                                     | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fpersistent-channels_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fpersistent-channels_nightly.json) |
+| [poncho][poncho]                     | Turns CLN into a [hosted channels][blip12] provider                                         |        |         |
+| [pruning][pruning]                   | This plugin manages pruning of bitcoind such that it can always sync                        |        |         |
+| [rebalance][rebalance]               | Keeps your channels balanced                                                                | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Frebalance_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Frebalance_nightly.json) |
+| [reckless][reckless]                 | An **experimental** plugin manager (search/install plugins)                                 |        |         |
+| [sauron][sauron]                     | A Bitcoin backend relying on [Esplora][esplora]'s API                                       |        |         |
+| [sitzprobe][sitzprobe]               | A Lightning Network payment rehearsal utility                                               |        |         |
+| [sling][sling]                       | Rebalance your channels with smart rules and built-in background tasks                      | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fsling_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fsling_nightly.json) |
+| [sparko][sparko]                     | RPC over HTTP with fine-grained permissions, SSE and spark-wallet support                   |        |         |
+| [summars][summars]                   | Print configurable summary of node, channels and optionally forwards, invoices, payments    | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fsummars_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fsummars_nightly.json) |
+| [trustedcoin][trustedcoin]           | Replace your Bitcoin Core with data from public block explorers                             |        |         |
+| [watchtower-client][watchtower-client]      | Watchtower client for The Eye of Satoshi                                                    |        |         |
+| [webhook][webhook]                   | Dispatches webhooks based from [event notifications][event-notifications]                   |        |         |
+| [zmq][zmq]                           | Publishes notifications via [ZeroMQ][zmq-home] to configured endpoints                      | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fzmq_main.json) | ![](https://img.shields.io/endpoint?url=https%3A%2F%2Flightningd.github.io%2Fplugins%2F.badges%2Fzmq_nightly.json) |
 
 ## Archived plugins
 
@@ -194,7 +195,7 @@ Python plugins developers must ensure their plugin to work with all Python versi
  - [Kotlin plugin guideline and example][kotlin-example] by @vincenzopalazzo
 
 [autopilot]: https://github.com/lightningd/plugins/tree/master/archived/autopilot
-[backup]: https://github.com/lightningd/plugins/tree/master/archived/backup
+[backup]: https://github.com/lightningd/plugins/tree/master/backup
 [blip12]: https://github.com/lightning/blips/blob/42cec1d0f66eb68c840443abb609a5a9acb34f8e/blip-0012.md
 [btcli4j]: https://github.com/clightning4j/btcli4j
 [c-api]: https://github.com/ElementsProject/lightning/blob/master/plugins/libplugin.h
@@ -205,7 +206,8 @@ Python plugins developers must ensure their plugin to work with all Python versi
 [cpp-api]: https://github.com/darosior/lightningcpp
 [csharp-example]: https://github.com/joemphilips/DotNetLightning/tree/master/examples/HelloWorldPlugin
 [currencyrate]: https://github.com/lightningd/plugins/tree/master/currencyrate
-[donations]: https://github.com/lightningd/plugins/tree/master/archived/donations
+[datastore]: https://github.com/lightningd/plugins/tree/master/datastore
+[donations]: https://github.com/lightningd/plugins/tree/master/donations
 [drain]: https://github.com/lightningd/plugins/tree/master/archived/drain
 [esplora]: https://github.com/Blockstream/esplora
 [event-notifications]: https://lightning.readthedocs.io/PLUGINS.html#event-notifications


### PR DESCRIPTION
This PR adds two columns for the `main` and `nightly` workflows to the "Available plugins" table in _README.md_ that displays badges indicating plugins' test results:

- **nightly**: Test results from the last scheduled nightly workflow run.
- **main**: Test results from the last workflow run triggered by a push to `master`. Workflow runs triggered by pull requests are ignored.

If a plugin has no tests, no badges are displayed. 

During the above workflow runs various data is generated and saved to the _.badges_ directory of the (to be created) `badges` branch. It is a two step process:

1. At the end of the workflow runs (`build-and-test` and `nightly-build-and-test` jobs) the test result ("passed" or "failed") for each plugin and Python version is saved to a separate file, e.g. _.badges/gather_data/main/backup/python3.12.txt_. 
2. In the completion `gather`  job the data from step 1 is collected and written to JSON files , e.g. _.badges/backup_main.json_ and _.badges/backup_nightly.json_. If the JSON data for a plugin has changed it is committed and pushed. This JSON data is then exposed through GitHub Pages which allows for the badges to be rendered dynamically.



Notes:
  - Branch `badges` needs to be created manually and then GitHub pages need to be configured with `Source` set to `Deploy from a branch` and with `Branch` set to `badges`.
  - Badges are rendered using https://shields.io/ and are cached up to 300 seconds. Therefore, it can take a while for a badge change to be displayed even when doing a page reload. I also noticed that the page sometimes needed to be reloaded in order for the badges to be updated when simply clicking on the `Code` tab. This may have been due to the browser still caching an older badge.

![image](https://github.com/lightningd/plugins/assets/157324775/a6272843-1285-41a8-8cfa-f027e875bf21)
Display of badges with the `holdinvoice` plugin CLN master tests currently failing. 

This PR also re-enables CI tests for the `feeadjuster` plugin by removing it from the list of excluded directories which it was added to erroneously while being unarchived.

Corresponding issue: https://github.com/lightningd/plugins/issues/494