### PR TITLE
feeadjuster: various updates/fixes

### DIFF
--- a/feeadjuster/README.md
+++ b/feeadjuster/README.md
@@ -22,3 +22,4 @@ the median fees from peers of peer.
 'median'. This allows over- or underbidding other nodes by a constant factor (default: 1.0).
 - `feeadjuster-max-htlc-steps` Default 0 (turned off). Sets the number of max htlc adjustment steps. If our local channel balance drops below a step level
 it will reduce the max htlc to that level, which can reduce local routing channel failures.  A value of 0 disables the stepping.
+- `feeadjuster-basefee` Default False, Also adjust base fee dynamically. Currently only affects median strategy.

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -22,6 +22,17 @@ plugin.mutex = Lock()
 plugin.mutex.acquire()
 
 
+def read_excludelist():
+    try:
+        with open('feeadjuster-exclude.list') as file:
+            exclude_list = [l.rstrip("\n") for l in file]
+            print("Excluding the channels with the nodes:", exclude_list)
+    except FileNotFoundError:
+        exclude_list = []
+        print("There is no feeadjuster-exclude.list given, applying the options to the channels with all peers.")
+    return exclude_list
+
+
 def get_adjusted_percentage(plugin: Plugin, scid: str):
     """
     For big channels, there may be a wide range where the liquidity is just okay.
@@ -298,13 +309,8 @@ def feeadjust(plugin: Plugin, scid: str = None):
     if plugin.fee_strategy == get_fees_median and not plugin.listchannels_by_dst:
         plugin.channels = plugin.rpc.listchannels()['channels']
     channels_adjusted = 0
-    try:
-        with open('feeadjuster-exclude.list') as file:
-            exclude_list = [l.rstrip("\n") for l in file]
-            print("Excluding the channels with the nodes:", exclude_list)
-    except FileNotFoundError:
-        exclude_list = []
-        print("There is no feeadjuster-exclude.list given, applying the options to the channels with all peers.")
+    exclude_list = read_excludelist()
+
     for chan in plugin.peerchannels:
         if chan["peer_id"] in exclude_list:
             continue

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -101,7 +101,8 @@ def get_config(plugin: Plugin, config: str):
 
     # now < 23.08
     result = plugin.rpc.listconfigs(config)
-    assert len(result)>0
+    if len(result) == 0:
+        return None
     return result[config]
 
 
@@ -364,9 +365,11 @@ def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
     plugin.fee_strategy = fee_strategy_switch.get(options.get("feeadjuster-feestrategy"), get_fees_global)
     plugin.median_multiplier = float(options.get("feeadjuster-median-multiplier"))
     plugin.adj_basefee = get_config(plugin, "fee-base")
-    assert plugin.adj_basefee is not None
+    if plugin.adj_basefee is None:
+        plugin.adj_basefee = 1000
     plugin.adj_ppmfee = get_config(plugin, "fee-per-satoshi")
-    assert plugin.adj_ppmfee is not None
+    if plugin.adj_ppmfee is None:
+        plugin.adj_ppmfee = 10
 
     # normalize the imbalance percentage value to 0%-50%
     if plugin.imbalance < 0 or plugin.imbalance > 1:

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -301,8 +301,9 @@ def feeadjust(plugin: Plugin, scid: str = None):
     This method is automatically called in plugin init, or can be called manually after a successful payment.
     Otherwise, the plugin keeps the fees up-to-date.
 
-    To stop setting the channels with a list of nodes place a file called `feeadjuster-exclude.list` in the
-    lightningd data directory with a simple line-by-line list of pubkeys.
+    To stop adjusting the channels for a set PeerIDs or SCIDs, place a file
+    called `feeadjuster-exclude.list` in the lightningd data directory with a
+    simple line-by-line list of PeerIDs (pubkeys) or SCIDs.
     """
     plugin.mutex.acquire(blocking=True)
     plugin.peerchannels = get_peerchannels(plugin)
@@ -312,7 +313,7 @@ def feeadjust(plugin: Plugin, scid: str = None):
     exclude_list = read_excludelist()
 
     for chan in plugin.peerchannels:
-        if chan["peer_id"] in exclude_list:
+        if scid in exclude_list or chan["peer_id"] in exclude_list:
             continue
         if chan["state"] == "CHANNELD_NORMAL":
             _scid = chan.get("short_channel_id")

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -15,6 +15,7 @@ plugin.adj_balances = {}
 plugin.our_node_id = None
 plugin.peerchannels = None
 plugin.channels = None
+plugin.excludelist = None
 # Users can configure this
 plugin.update_threshold = 0.05
 # forward_event must wait for init
@@ -204,6 +205,8 @@ def significant_update(plugin: Plugin, scid: str):
 def maybe_adjust_fees(plugin: Plugin, scids: list):
     channels_adjusted = 0
     for scid in scids:
+        if scid in plugin.exclude_list or get_peer_id_for_scid(plugin, scid) in plugin.exclude_list:
+            continue
         our = plugin.adj_balances[scid]["our"]
         total = plugin.adj_balances[scid]["total"]
         percentage = our / total
@@ -310,10 +313,10 @@ def feeadjust(plugin: Plugin, scid: str = None):
     if plugin.fee_strategy == get_fees_median and not plugin.listchannels_by_dst:
         plugin.channels = plugin.rpc.listchannels()['channels']
     channels_adjusted = 0
-    exclude_list = read_excludelist()
+    plugin.exclude_list = read_excludelist()
 
     for chan in plugin.peerchannels:
-        if scid in exclude_list or chan["peer_id"] in exclude_list:
+        if scid in plugin.exclude_list or chan["peer_id"] in plugin.exclude_list:
             continue
         if chan["state"] == "CHANNELD_NORMAL":
             _scid = chan.get("short_channel_id")

--- a/feeadjuster/feeadjuster.py
+++ b/feeadjuster/feeadjuster.py
@@ -201,8 +201,9 @@ def maybe_adjust_fees(plugin: Plugin, scids: list):
         # select ideal values per channel
         fees = plugin.fee_strategy(plugin, scid)
         if fees is not None:
-            base = int(fees['base'])
             ppm = int(fees['ppm'])
+            if plugin.basefee:
+                base = int(fees['base'])
 
         # reset to normal fees if imbalance is not high enough
         if (percentage > plugin.imbalance and percentage < 1 - plugin.imbalance):
@@ -349,6 +350,7 @@ def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
     plugin.big_enough_liquidity = Millisatoshi(options.get("feeadjuster-enough-liquidity"))
     plugin.imbalance = float(options.get("feeadjuster-imbalance"))
     plugin.max_htlc_steps = int(options.get("feeadjuster-max-htlc-steps"))
+    plugin.basefee = bool(options.get("feeadjuster-basefee"))
     adjustment_switch = {
         "soft": get_ratio_soft,
         "hard": get_ratio_hard,
@@ -395,7 +397,8 @@ def init(options: dict, configuration: dict, plugin: Plugin, **kwargs):
                f"adjustment_method: {plugin.get_ratio.__name__}, "
                f"fee_strategy: {plugin.fee_strategy.__name__}, "
                f"listchannels_by_dst: {plugin.listchannels_by_dst},"
-               f"max_htlc_steps: {plugin.max_htlc_steps}")
+               f"max_htlc_steps: {plugin.max_htlc_steps},"
+               f"basefee: {plugin.basefee}")
     plugin.mutex.release()
     feeadjust(plugin)
 
@@ -475,5 +478,11 @@ plugin.add_option(
     "liquidity, which can reduce local routing channel failures."
     "A value of 0 disables the stepping.",
     "string"
+)
+plugin.add_option(
+    "feeadjuster-basefee",
+    False,
+    "Also adjust base fee dynamically. Currently only affects median strategy.",
+    "bool"
 )
 plugin.run()

--- a/feeadjuster/test_feeadjuster.py
+++ b/feeadjuster/test_feeadjuster.py
@@ -61,6 +61,7 @@ def pay(l, ll, amount):
     route = l.rpc.getroute(ll.info["id"], amount, riskfactor=0, fuzzpercent=0)
     l.rpc.sendpay(route["route"], invoice["payment_hash"], payment_secret=invoice.get('payment_secret'))
     l.rpc.waitsendpay(invoice["payment_hash"])
+    l.wait_for_htlcs()
 
 
 def sync_gossip(nodes, scids):
@@ -345,3 +346,36 @@ def test_feeadjuster_median(node_factory):
     chan_b = l2.rpc.listpeerchannels(l3.info['id'])['channels'][0]
     assert chan_b['fee_base_msat'] == 1337
     assert chan_b['fee_proportional_millionths'] < 42  # we could do the actual ratio math, but meh
+
+
+def test_excludelist(node_factory, directory):
+    opts1 = {'may_reconnect': True}
+    opts2 = {'may_reconnect': True, "plugin": plugin_path,
+        "feeadjuster-deactivate-fee-update": None,
+        "feeadjuster-deactivate-fuzz": None,
+        "feeadjuster-imbalance": 0.5}
+    l1, l2, l3 = node_factory.line_graph(3, opts=[opts1, opts2, opts1], wait_for_announce=True)
+
+    scid_a = l2.rpc.listpeerchannels(l1.info["id"])["channels"][0]["short_channel_id"]
+    scid_b = l2.rpc.listpeerchannels(l3.info["id"])["channels"][0]["short_channel_id"]
+
+    # without exclude list a notification is printed
+    assert l2.rpc.feeadjust(scid_a) == "1 channel(s) adjusted"
+    assert l2.daemon.is_in_log("There is no feeadjuster-exclude.list given, applying the options to the channels with all peers.")
+
+    # stop l2, create a exlude list file containing [l1_id] and restart l2
+    l2.stop()
+    l2path = os.path.join(directory, 'lightning-2', 'regtest')
+    file = open(os.path.join(l2path, 'feeadjuster-exclude.list'), 'w+')
+    file.write(l1.info['id'])
+    file.close()
+    l2.start()
+    l2.daemon.is_in_log(f"Excluding the channels with the nodes: ['{l1.info['id']}']")
+    l2.connect(l1)
+    l2.connect(l3)
+
+    # Do some payments to have a proper imbalance and check
+    pay(l1, l2, 10**8)
+    assert l2.rpc.feeadjust(scid_a) == "0 channel(s) adjusted"
+    pay(l2, l3, 10**8)
+    assert l2.rpc.feeadjust(scid_b) == "1 channel(s) adjusted"

--- a/feeadjuster/test_feeadjuster.py
+++ b/feeadjuster/test_feeadjuster.py
@@ -325,7 +325,8 @@ def test_feeadjuster_median(node_factory):
         "plugin": plugin_path,
         "feeadjuster-deactivate-fuzz": None,
         "feeadjuster-imbalance": 0.5,
-        "feeadjuster-feestrategy": "median"
+        "feeadjuster-feestrategy": "median",
+        "feeadjuster-basefee": True,
     }
     l1, l2, l3, _ = node_factory.line_graph(4, opts=[opts, l2_opts, opts, opts],
                                             wait_for_announce=True)


### PR DESCRIPTION
Ok so i was bored and went over the feeadjuster plugin because @grubles said there were problems with it.

I found a compatibility issue in #457 with `listconfigs` so i made a wrapper function to support both the old and new structure of `listconfigs`.
I went over all the feeadjuster issues that were reporting bugs and most of them are probably users who updated their node but not their `pyln-client`, since we can't raise the version in `requirements.txt` ourselves because that would also break compatibility (maybe fixed by [this](https://github.com/ElementsProject/lightning/pull/7173) ?).

But i also found an actual issue in #199 which i fixed by always getting the channel balance from a rpc call to `listpeers`/`listpeerchannels` instead of doing math with the data from the `forward_event`. We need to do this because between forwards there can be invoices getting paid, payments sent out or channel splices. Listening for these events is rather pointless since they don't contain data about what channel balances changed, so we would have to do rpc calls anyways. Unfortunately `listpeers`/`listpeerchannels` does not update quite as fast as the `forward_event` so we have to wait a bit.

Then @grubles pointed me to the PR #467 from @m-schmoock and i incorporated it together with my fixes.

Then i tested `feeadjuster` against CLN [23.02.2](https://github.com/daywalker90/plugins/actions/runs/9008084960), [23.05.2](https://github.com/daywalker90/plugins/actions/runs/9008084965), [23.08.1](https://github.com/daywalker90/plugins/actions/runs/9008084979), [23.11.2](https://github.com/daywalker90/plugins/actions/runs/9008084968) and [24.02.2](https://github.com/daywalker90/plugins/actions/runs/9008084957)

I had to adjust the tests a bit to accomodate for the bad gossip retransmission in older CLN versions (it's still slightly flaky but who cares)

<sub>just rewrite it in rust lul</sub>