### PR TITLE
Bugfix nightly workflow

### DIFF
--- a/.ci/update_badges.py
+++ b/.ci/update_badges.py
@@ -134,7 +134,7 @@ def push_badges_data(workflow, num_of_python_versions):
     any_changes = False
     for plugin in plugins:
         results = []
-        _dir = f".badges/gather_data/main/{plugin.name}"
+        _dir = f".badges/gather_data/{workflow}/{plugin.name}"
         if os.path.exists(_dir):
             for child in Path(_dir).iterdir():
                 result = child.read_text().strip()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
         export CLN_PATH=${{ github.workspace }}/lightning
         pip3 install --upgrade pip
         pip3 install --user -U virtualenv pip > /dev/null
-        python3 .ci/test.py nightly --update-badges
+        python3 .ci/test.py nightly ${{ matrix.python-version }} --update-badges
 
   gather:
     # A dummy task that depends on the full matrix of tests, and signals completion.
@@ -110,6 +110,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Complete
         run: |
-          echo "Updating badges data..."
-          python3 .ci/update_badges.py main 5  # We test for 5 distinct Python versions
-          echo "CI completed"
+          echo "Updating badges data for nightly..."
+          python3 .ci/update_badges.py nightly 5  # We test for 5 distinct Python versions
+          echo "CI completed."


### PR DESCRIPTION
This PR fixes three issues for the `nightly` workflow related to PR https://github.com/lightningd/plugins/pull/509:

* Missing `python_version` argument for _test.py_.
* Wrong `workflow` argument for _update_badges.py_.
* Wrong path to `gather_data` dir in _update_badges.py_.