### PR TITLE
Add default badges JSON data

### DIFF
--- a/.badges/btcli4j_main.json
+++ b/.badges/btcli4j_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/btcli4j_nightly.json
+++ b/.badges/btcli4j_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/event-websocket_main.json
+++ b/.badges/event-websocket_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/event-websocket_nightly.json
+++ b/.badges/event-websocket_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/go-lnmetrics.reporter_main.json
+++ b/.badges/go-lnmetrics.reporter_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/go-lnmetrics.reporter_nightly.json
+++ b/.badges/go-lnmetrics.reporter_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/graphql_main.json
+++ b/.badges/graphql_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/graphql_nightly.json
+++ b/.badges/graphql_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/invoice-queue_main.json
+++ b/.badges/invoice-queue_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/invoice-queue_nightly.json
+++ b/.badges/invoice-queue_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/lightning-qt_main.json
+++ b/.badges/lightning-qt_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/lightning-qt_nightly.json
+++ b/.badges/lightning-qt_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/listmempoolfunds_main.json
+++ b/.badges/listmempoolfunds_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/listmempoolfunds_nightly.json
+++ b/.badges/listmempoolfunds_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/nloop_main.json
+++ b/.badges/nloop_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/nloop_nightly.json
+++ b/.badges/nloop_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/paythrough_main.json
+++ b/.badges/paythrough_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/paythrough_nightly.json
+++ b/.badges/paythrough_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/poncho_main.json
+++ b/.badges/poncho_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/poncho_nightly.json
+++ b/.badges/poncho_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/pruning_main.json
+++ b/.badges/pruning_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/pruning_nightly.json
+++ b/.badges/pruning_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/sauron_main.json
+++ b/.badges/sauron_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/sauron_nightly.json
+++ b/.badges/sauron_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/sitzprobe_main.json
+++ b/.badges/sitzprobe_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/sitzprobe_nightly.json
+++ b/.badges/sitzprobe_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/trustedcoin_main.json
+++ b/.badges/trustedcoin_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/trustedcoin_nightly.json
+++ b/.badges/trustedcoin_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/watchtower-client_main.json
+++ b/.badges/watchtower-client_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/watchtower-client_nightly.json
+++ b/.badges/watchtower-client_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/webhook_main.json
+++ b/.badges/webhook_main.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}

--- a/.badges/webhook_nightly.json
+++ b/.badges/webhook_nightly.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "", "message": " ? ", "color": "yellow"}


### PR DESCRIPTION
This PR adds default JSON data to the `badges` branch for all plugins without badges in the README.
For those plugins yellow badges with a question mark are displayed. Then, as soon as tests are added for a specific plugin the JSON data will be overwritten, and either a green (passing) or red (failing) badge will be displayed.

See corresponding PR https://github.com/lightningd/plugins/pull/556