### PR TITLE
refactor get_testfiles

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -8,8 +8,7 @@ import json
 from itertools import chain
 from pathlib import Path
 
-from utils import (Plugin, configure_git, enumerate_plugins, get_testfiles,
-                   has_testfiles)
+from utils import (Plugin, configure_git, enumerate_plugins)
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -160,11 +159,11 @@ def install_pyln_testing(pip_path):
 def run_one(p: Plugin) -> bool:
     print("Running tests on plugin {p.name}".format(p=p))
 
-    if not has_testfiles(p):
+    if not p.testfiles:
         print("No test files found, skipping plugin {p.name}".format(p=p))
         return True
 
-    print("Found {ctestfiles} test files, creating virtualenv and running tests".format(ctestfiles=len(get_testfiles(p))))
+    print("Found {ctestfiles} test files, creating virtualenv and running tests".format(ctestfiles=len(p.testfiles)))
     print("##[group]{p.name}".format(p=p))
 
     # Create a virtual env
@@ -225,7 +224,7 @@ def collect_gather_data(results: list, success: bool) -> dict:
     gather_data = {}
     for t in results:
         p = t[0]
-        if has_testfiles(p):
+        if p.testfiles:
             if success or t[1]:
                 gather_data[p.name] = "passed"
             else:

--- a/.ci/utils.py
+++ b/.ci/utils.py
@@ -10,6 +10,7 @@ Plugin = namedtuple(
         "path",
         "language",
         "framework",
+        "testfiles",
         "details",
     ],
 )
@@ -31,18 +32,14 @@ def configure_git():
     subprocess.run(["git", "config", "--global", "user.name", '"lightningd"'])
 
 
-def get_testfiles(p: Plugin) -> List[PosixPath]:
+def get_testfiles(p: Path) -> List[PosixPath]:
     test_files = []
-    for x in p.path.iterdir():
+    for x in p.iterdir():
         if x.is_dir() and x.name == "tests":
             test_files.extend([y for y in x.iterdir() if y.is_file() and y.name.startswith("test_") and y.name.endswith(".py")])
         elif x.is_file() and x.name.startswith("test_") and x.name.endswith(".py"):
             test_files.append(x)
     return test_files
-
-
-def has_testfiles(p: Plugin) -> bool:
-    return len(get_testfiles(p)) > 0
 
 
 def list_plugins(plugins: list) -> str:
@@ -70,6 +67,7 @@ def enumerate_plugins(basedir: Path) -> Generator[Plugin, None, None]:
             path=p,
             language="python",
             framework="pip",
+            testfiles=get_testfiles(p),
             details={
                 "requirements": p / Path("requirements.txt"),
                 "devrequirements": p / Path("requirements-dev.txt"),
@@ -82,6 +80,7 @@ def enumerate_plugins(basedir: Path) -> Generator[Plugin, None, None]:
             path=p,
             language="python",
             framework="poetry",
+            testfiles=get_testfiles(p),
             details={
                 "pyproject": p / Path("pyproject.toml"),
             },
@@ -93,6 +92,7 @@ def enumerate_plugins(basedir: Path) -> Generator[Plugin, None, None]:
             path=p,
             language="other",
             framework="generic",
+            testfiles=get_testfiles(p),
             details={
                 "requirements": p / Path("tests/requirements.txt"),
                 "setup": p / Path("tests/setup.sh"),


### PR DESCRIPTION
Currently we are checking the _badges_ branch for testfiles when calling `collect_gather_data`-> `has_testfiles`. That branch is and will not be up2date with the master branch so we should avoid that. And instead of switching branches around i rather save the testfiles once inside the plugin.