### PR TITLE
CI: nightly fixes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly Integration Tests (master)
 on:
   schedule:
     - cron: "21 2 * * *"
+  workflow_dispatch:
 
 jobs:
   nightly-build-and-test:
@@ -21,6 +22,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Download Bitcoin & install binaries
       run: |
@@ -66,20 +72,15 @@ jobs:
           pytest-custom-exit-code==0.3.0 \
           pytest-json-report
 
-        poetry install
+        poetry install --with=dev
         poetry update
-        poetry export --without-hashes -f requirements.txt --output requirements.txt
+        poetry export --with=dev --without-hashes -f requirements.txt --output requirements.txt
         pip install --user -U -r requirements.txt
         pip install --user contrib/pyln-client contrib/pyln-testing flaky
 
         ./configure --disable-valgrind
         make -j 16
         sudo make install
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Right now all plugins fail the nightly python 3.12 tests and are therefore marked as failing for master despite most plugins actually working fine on master.

This is because python dependency management is a mess. The problem was coincurve 18 no longer working in python 3.12.4. We got it updated in CLN but until there is a new python packages release this alone doesn't do anything yet. We should install the dependencies in development mode, which installs them from source. I think this is what we actually want since the purpose is to test the plugins against any changes in CLN and the python framework on master.

You'd think that a simple `poetry install --with=dev` would suffice but you'd be mistaken. Poetry will only install top level dependencies in dev mode and not sub-dependencies. With this you'll still get coincurve 18. The way i did it was to use the requirements.txt from the `poetry export --with=dev` command to setup the pip and generic plugin's test environment.

If a plugins fails to setup it's environment it will now fail the test instead of cancelling the nightly workflow.

I've added the `workflow_dispatch` trigger, so we can run nightly manually for testing purposes.