### PR TITLE
Currencyrate update

### DIFF
--- a/currencyrate/README.md
+++ b/currencyrate/README.md
@@ -1,7 +1,7 @@
 # Currencyrate plugin
 
 This plugin provides Bitcoin currency conversion functions using various
-different backends and taking the median.  It caches results for an hour.
+different backends and taking the median. It caches results for an hour.
 
 ## Installation
 
@@ -17,8 +17,7 @@ For general plugin installation instructions see the repos main
   would be "USD,last_trade".
 * --disable-source: Disable the source with this name.
 
-For c-lightning versions 0.9.3 and above, you can specify these
-options multiple times to add or disable multiple sources.
+You can specify these options multiple times to add or disable multiple sources.
 
 ## Commands
 
@@ -27,7 +26,7 @@ options multiple times to add or disable multiple sources.
 ```
 $ lightning-cli currencyrates USD
 {
-   "localbitcoins": "5347227msat",
+   "coindesk": "5347227msat",
    "bitstamp": "5577515msat",
    "coingecko": "5579273msat",
 }
@@ -48,7 +47,6 @@ $ lightning-cli currencyconvert 100 USD
 Thanks to those services who provide this information.  Coindesk require
 a blurb, so I did that for everyone (quoting from their front page):
 
-* localbitcoins.com: "Buy and Sell Bitcoin Everywhere"
 * www.bitstamp.net: "The original global crypto exchange."
 * api.coingecko.com: "The world's most comprehensive cryptocurrency API"
 * api.coindesk.com: "Powered by CoinDesk: https://www.coindesk.com/price/bitcoin"

--- a/currencyrate/requirements.txt
+++ b/currencyrate/requirements.txt
@@ -1,4 +1,5 @@
-pyln-client>=0.7.3
-requests>=2.10.0
-requests[socks]>=2.10.0
-cachetools
+pyln-client>=23
+requests>=2.32.2
+requests[socks]>=2.32.2
+urllib3>=2.2.2
+cachetools>=5.3.3

--- a/currencyrate/test_currencyrate.py
+++ b/currencyrate/test_currencyrate.py
@@ -31,7 +31,7 @@ def test_currencyrate(node_factory):
     opts = {
         "plugin": plugin_path,
         "allow-deprecated-apis": deprecated_apis,
-        "disable-source": "bitstamp",
+        "disable-source": ["bitstamp", "coinbase"],
     }
     l1 = node_factory.get_node(options=opts)
     plugins = [os.path.basename(p["name"]) for p in l1.rpc.plugin("list")["plugins"]]
@@ -40,6 +40,7 @@ def test_currencyrate(node_factory):
     rates = l1.rpc.call("currencyrates", ["USD"])
     LOGGER.info(rates)
     assert "bitstamp" not in rates
+    assert "coinbase" not in rates
     assert "coingecko" in rates
     assert extract_digits(rates["coingecko"]) > 0
 


### PR DESCRIPTION
Currencyrate starts failing tests on master so i took it upon me to look at it and gave i a couple updates.

There was some code for pre v0.9.3, i think we can safely remove that.

The tests failed because of:

```
lightningd-1 2024-07-01T13:02:12.332Z UNUSUAL plugin-currencyrate.py: Traceback (most recent call last):
lightningd-1 2024-07-01T13:02:12.333Z UNUSUAL plugin-currencyrate.py:   File \"/home/runner/work/plugins/plugins/currencyrate/currencyrate.py\", line 156, in <module>
lightningd-1 2024-07-01T13:02:12.333Z UNUSUAL plugin-currencyrate.py:     plugin.options['add-source']['multi'] = True
lightningd-1 2024-07-01T13:02:12.333Z UNUSUAL plugin-currencyrate.py:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
lightningd-1 2024-07-01T13:02:12.333Z UNUSUAL plugin-currencyrate.py: TypeError: 'Option' object does not support item assignment
```

I removed those lines and just used the multi argument when creating the option. We are essentially dropping support for <0.9.3 or something.

My linter was also complaining about the import `from requests.packages.urllib3.util.retry import Retry` and after a quick stackoverflow search it's now best practice to use urllib3 directly.

Updated dependencies aswell. pyln-client versions should always be `>=(minimum supported version)`. If you think 23 is too new let me know.

Ontop of #567 and #568 