### PR TITLE
sauron: changed Retry param name from method_whitelist to allowed_methods

### DIFF
--- a/sauron/sauron.py
+++ b/sauron/sauron.py
@@ -29,7 +29,7 @@ def fetch(url):
         backoff_factor=1,
         total=10,
         status_forcelist=[429, 500, 502, 503, 504],
-        method_whitelist=["HEAD", "GET", "OPTIONS"],
+        allowed_methods=["HEAD", "GET", "OPTIONS"],
     )
     adapter = HTTPAdapter(max_retries=retry_strategy)
 


### PR DESCRIPTION
Trying to run the sauron plugin today, it appears the Retry constructor may have changed the name of `method_whitelist` to `allowed_methods`.

urllib3 Retry:
https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry

Before changing it I got the error:

	(venv) clite@localhost:~$ lightningd --mainnet --disable-plugin bcli --plugin /home/clite/plugins/sauron/sauron.py --sauron-api-endpoint https://blockstream.info/api
	2024-07-24T13:54:41.216Z INFO    lightningd: v24.05
	2024-07-24T13:54:41.485Z INFO    lightningd: Creating configuration directory /home/clite/.lightning/bitcoin
	2024-07-24T13:54:41.487Z INFO    plugin-manager: /home/clite/lightning/usr/libexec/c-lightning/plugins/bcli: disabled via disable-plugin
	2024-07-24T13:54:41.944Z INFO    plugin-wss-proxy: Killing plugin: disabled itself: No module named 'websockets'
	2024-07-24T13:54:41.946Z INFO    plugin-clnrest: Killing plugin: disabled itself: No module named 'gevent'
	2024-07-24T13:54:42.430Z INFO    plugin-sauron.py: RPC method 'getchaininfo' does not have a docstring.
	2024-07-24T13:54:42.431Z INFO    plugin-sauron.py: RPC method 'getrawblockbyheight' does not have a docstring.
	2024-07-24T13:54:42.431Z INFO    plugin-sauron.py: RPC method 'sendrawtransaction' does not have a docstring.
	2024-07-24T13:54:42.431Z INFO    plugin-sauron.py: RPC method 'getutxout' does not have a docstring.
	2024-07-24T13:54:42.432Z INFO    plugin-sauron.py: RPC method 'estimatefees' does not have a docstring.
	2024-07-24T13:54:42.484Z INFO    lightningd: Creating database
	2024-07-24T13:54:42.582Z UNUSUAL hsmd: HSM: created new hsm_secret file
	2024-07-24T13:54:42.612Z INFO    plugin-sauron.py: Sauron plugin initialized
	2024-07-24T13:54:42.612Z INFO    plugin-sauron.py: 
	2024-07-24T13:54:42.613Z INFO    plugin-sauron.py: 
	2024-07-24T13:54:42.613Z INFO    plugin-sauron.py:                      Three::rings
	2024-07-24T13:54:42.613Z INFO    plugin-sauron.py:                 for:::the::Elven-Kings
	2024-07-24T13:54:42.613Z INFO    plugin-sauron.py:              under:the:sky,:Seven:for:the
	2024-07-24T13:54:42.614Z INFO    plugin-sauron.py:            Dwarf-Lords::in::their::halls:of
	2024-07-24T13:54:42.614Z INFO    plugin-sauron.py:           stone,:Nine             for:Mortal
	2024-07-24T13:54:42.614Z INFO    plugin-sauron.py:          :::Men:::     ________     doomed::to
	2024-07-24T13:54:42.614Z INFO    plugin-sauron.py:        die.:One   _,-'...:... `-.    for:::the
	2024-07-24T13:54:42.614Z INFO    plugin-sauron.py:        ::Dark::  ,- .:::::::::::. `.   Lord::on
	2024-07-24T13:54:42.615Z INFO    plugin-sauron.py:       his:dark ,'  .:::::zzz:::::.  `.  :throne:
	2024-07-24T13:54:42.615Z INFO    plugin-sauron.py:       In:::the/    ::::dMMMMMb::::    \\ Land::of
	2024-07-24T13:54:42.615Z INFO    plugin-sauron.py:       :Mordor:\\    ::::dMMmgJP::::    / :where::
	2024-07-24T13:54:42.615Z INFO    plugin-sauron.py:       ::the::: '.  '::::YMMMP::::'  ,'  Shadows:
	2024-07-24T13:54:42.615Z INFO    plugin-sauron.py:        lie.::One  `. ``:::::::::'' ,'    Ring::to
	2024-07-24T13:54:42.616Z INFO    plugin-sauron.py:        ::rule::    `-._```:'''_,-'     ::them::
	2024-07-24T13:54:42.616Z INFO    plugin-sauron.py:        all,::One      `-----'        ring::to
	2024-07-24T13:54:42.616Z INFO    plugin-sauron.py:          ::find:::                  them,:One
	2024-07-24T13:54:42.616Z INFO    plugin-sauron.py:           Ring:::::to            bring::them
	2024-07-24T13:54:42.616Z INFO    plugin-sauron.py:             all::and::in:the:darkness:bind
	2024-07-24T13:54:42.616Z INFO    plugin-sauron.py:               them:In:the:Land:of:Mordor
	2024-07-24T13:54:42.617Z INFO    plugin-sauron.py:                  where:::the::Shadows
	2024-07-24T13:54:42.617Z INFO    plugin-sauron.py:                       :::lie.:::
	2024-07-24T13:54:42.617Z INFO    plugin-sauron.py: 
	2024-07-24T13:54:42.617Z INFO    plugin-sauron.py: 
	/home/clite/plugins/sauron/sauron.py error: bad response to getchaininfo (bad 'result' field: Parsing '{result:': object does not have member result), response was {"jsonrpc": "2.0", "id": "cln:getchaininfo#20", "error": {"code": -32600, "message": "Error while processing getchaininfo: __init__() got an unexpected keyword argument 'method_whitelist'", "traceback": "Traceback (most recent call last):\n  File \"/home/clite/venv/lib/python3.8/site-packages/pyln/client/plugin.py\", line 646, in _dispatch_request\n    result = self._exec_func(method.func, request)\n  File \"/home/clite/venv/lib/python3.8/site-packages/pyln/client/plugin.py\", line 626, in _exec_func\n    ret = func(*ba.args, **ba.kwargs)\n  File \"/home/clite/plugins/sauron/sauron.py\", line 76, in getchaininfo\n    genesis_req = fetch(blockhash_url)\n  File \"/home/clite/plugins/sauron/sauron.py\", line 28, in fetch\n    retry_strategy = Retry(\nTypeError: __init__() got an unexpected keyword argument 'method_whitelist'\n"}}

After changing it, it appears to run fine.

fixes #516