### PR TITLE
remove ssh requirement for torq plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,4 +72,4 @@
 	url = https://github.com/nosedam/ln-address-pay
 [submodule "torq-plugin"]
 	path = torq-plugin
-	url = git@github.com:lncapital/torq-cln-plugin.git
+	url = https://github.com/lncapital/torq-cln-plugin


### PR DESCRIPTION
This was causing reckless to fail when users don't have a github credential with ssh access. See
https://github.com/ElementsProject/lightning/issues/7635