### PR TITLE
CI: don't upgrade generic env's python dependencies

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -135,7 +135,7 @@ def prepare_generic(p: Plugin, directory: Path, env: dict, workflow: str) -> boo
     if p.details["requirements"].exists():
         print(f"Installing requirements from {p.details['requirements']}")
         subprocess.check_call(
-            [pip_path, "install", "-U", *pip_opts, "-r", p.details["requirements"]],
+            [pip_path, "install", *pip_opts, "-r", p.details["requirements"]],
             stderr=subprocess.STDOUT,
         )
 


### PR DESCRIPTION
We don't upgrade python dependencies in the other types (python/poetry). This would cause the generic type to upgrade `pyln-testing` beyond the tested CLN version and `pyln-testing` is not always backwards compatible.

Example run with fix: https://github.com/daywalker90/plugins/actions/runs/12252218795

Issue reported by @chrisguida on discord