### PR TITLE
CI: setup cargo env for nightly make install

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,8 +79,8 @@ jobs:
         pip install --user contrib/pyln-client contrib/pyln-testing flaky
 
         ./configure --disable-valgrind
-        make -j 16
-        sudo make install
+        make -j $(nproc)
+        sudo -E bash -c "source $HOME/.cargo/env && rustup default stable && make install"
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Also lets not assume the amount of cores the CI has. For some reason during make install cargo is being run which is not available in the default sudo env. This change makes it available.

Fixes #621