### PR TITLE
CI: install pyln-testing before running generic setup

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -139,6 +139,11 @@ def prepare_generic(p: Plugin, directory: Path, env: dict, workflow: str) -> boo
             stderr=subprocess.STDOUT,
         )
 
+    if workflow == "nightly":
+        install_dev_pyln_testing(pip_path)
+    else:
+        install_pyln_testing(pip_path)
+
     if p.details["setup"].exists():
         print(f"Running setup script from {p.details['setup']}")
         subprocess.check_call(
@@ -146,11 +151,6 @@ def prepare_generic(p: Plugin, directory: Path, env: dict, workflow: str) -> boo
             env=env,
             stderr=subprocess.STDOUT,
         )
-
-    if workflow == "nightly":
-        install_dev_pyln_testing(pip_path)
-    else:
-        install_pyln_testing(pip_path)
 
     subprocess.check_call([pip_path, "freeze"])
     return True


### PR DESCRIPTION
In the generic setup the python dependencies installation should be done before custom code from the setup.sh is executed. Since `install_dev_pyln_testing` installs things like `protobuf` the version can change between generating grpc bindings and running the tests which causes errors (see holdinvoice erroring on nightly but not 24.11)