### PR TITLE
Poetry deprecation fixes

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -16,6 +16,7 @@ global_dependencies = [
     "pytest",
     "pytest-xdist",
     "pytest-timeout",
+    "poetry-plugin-export",
 ]
 
 pip_opts = ["-qq"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
           pytest-custom-exit-code==0.3.0 \
           pytest-json-report
 
-        poetry install
+        poetry install --no-root
         poetry update
         poetry export --without-hashes -f requirements.txt --output requirements.txt
         pip install --user -U -r requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,6 +169,7 @@ jobs:
         pip3 install --user -U \
           pip \
           poetry \
+          poetry-plugin-export \
           wheel \
           blinker \
           pytest-custom-exit-code==0.3.0 \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,6 +67,7 @@ jobs:
         pip3 install --user -U \
           pip \
           poetry \
+          poetry-plugin-export \
           wheel \
           blinker \
           pytest-custom-exit-code==0.3.0 \


### PR DESCRIPTION
I saw some fresh problems in the CI with poetry in python 3.11:

```
The command "export" does not exist.
```

```
Warning: The current project could not be installed: No file/folder found for package cln-meta-project
If you do not want to install the current project use --no-root.
```

I remembered this deprecation warning:

```
Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.
In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
```

So i added the dependency manually aswell as the --no-root. Let's hope it doesn't break the other versions.