### PR TITLE
sauron: make tests more robust

### DIFF
--- a/sauron/requirements.txt
+++ b/sauron/requirements.txt
@@ -1,2 +1,2 @@
-pyln-client>=23.2,<=24.5
+pyln-client>=23.2
 requests[socks]>=2.23.0

--- a/sauron/tests/test_sauron_esplora_signet.py
+++ b/sauron/tests/test_sauron_esplora_signet.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import os
-
 import pyln
 import pytest
 from pyln.testing import utils
@@ -10,20 +9,29 @@ from util import LightningD
 
 pyln.testing.fixtures.network_daemons["signet"] = utils.BitcoinD
 
-
 class LightningNode(utils.LightningNode):
     def __init__(self, *args, **kwargs):
         pyln.testing.utils.TEST_NETWORK = "signet"
         utils.LightningNode.__init__(self, *args, **kwargs)
         lightning_dir = args[1]
-        self.daemon = LightningD(lightning_dir, None, port=self.daemon.port)  # noqa: F405
-        options = {
-            "disable-plugin": "bcli",
+        old_opts = self.daemon.opts
+        self.daemon = LightningD(lightning_dir, None)  # noqa: F405
+        new_opts = {
+            "disable-plugin": ["bcli"],
             "network": "signet",
             "plugin": os.path.join(os.path.dirname(__file__), "../sauron.py"),
             "sauron-api-endpoint": "https://blockstream.info/signet/api",
         }
-        self.daemon.opts.update(options)
+        self.daemon.opts.update(old_opts)
+        self.daemon.opts.update(new_opts)
+        opts_to_disable = [
+            "bitcoin-datadir",
+            "bitcoin-rpcpassword",
+            "bitcoin-rpcuser",
+            "dev-bitcoind-poll",
+        ]
+        for opt in opts_to_disable:
+            self.daemon.opts.pop(opt)
 
     # Monkey patch
     def set_feerates(self, feerates, wait_for_effect=True):
@@ -36,7 +44,7 @@ def node_cls(monkeypatch):
     yield LightningNode
 
 
-def test_rpc_getchaininfo(node_factory):
+def test_esplora_signet_getchaininfo(node_factory):
     """
     Test getchaininfo
     """
@@ -52,7 +60,7 @@ def test_rpc_getchaininfo(node_factory):
     assert not response["ibd"]
 
 
-def test_rpc_getrawblockbyheight(node_factory):
+def test_esplora_signet_getrawblockbyheight(node_factory):
     """
     Test getrawblockbyheight
     """
@@ -67,7 +75,7 @@ def test_rpc_getrawblockbyheight(node_factory):
     assert response == expected_response
 
 @pytest.mark.skip(reason="testing_theory")
-def test_rpc_sendrawtransaction_invalid(node_factory):
+def test_esplora_signet_sendrawtransaction_invalid(node_factory):
     """
     Test sendrawtransaction
     """
@@ -84,7 +92,7 @@ def test_rpc_sendrawtransaction_invalid(node_factory):
     assert response.get("success") is False, "Expected success to be False"
 
 
-def test_rpc_getutxout(node_factory):
+def test_esplora_signet_getutxout(node_factory):
     """
     Test getutxout
     """
@@ -105,7 +113,7 @@ def test_rpc_getutxout(node_factory):
     assert response == expected_response
 
 
-def test_rpc_estimatefees(node_factory):
+def test_esplora_signet_estimatefees(node_factory):
     """
     Test estimatefees
     """

--- a/sauron/tests/test_sauron_esplora_tor_proxy.py
+++ b/sauron/tests/test_sauron_esplora_tor_proxy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import os
-
 import pyln
 import pytest
 from pyln.testing import utils
@@ -10,21 +9,30 @@ from util import LightningD
 
 pyln.testing.fixtures.network_daemons["bitcoin"] = utils.BitcoinD
 
-
 class LightningNode(utils.LightningNode):
     def __init__(self, *args, **kwargs):
         pyln.testing.utils.TEST_NETWORK = "bitcoin"
         utils.LightningNode.__init__(self, *args, **kwargs)
         lightning_dir = args[1]
-        self.daemon = LightningD(lightning_dir, None, port=self.daemon.port)  # noqa: F405
-        options = {
-            "disable-plugin": "bcli",
+        old_opts = self.daemon.opts
+        self.daemon = LightningD(lightning_dir, None)  # noqa: F405
+        new_opts = {
+            "disable-plugin": ["bcli"],
             "network": "bitcoin",
             "plugin": os.path.join(os.path.dirname(__file__), "../sauron.py"),
             "sauron-api-endpoint": "https://blockstream.info/api",
             "sauron-tor-proxy": "localhost:9050",
         }
-        self.daemon.opts.update(options)
+        self.daemon.opts.update(old_opts)
+        self.daemon.opts.update(new_opts)
+        opts_to_disable = [
+            "bitcoin-datadir",
+            "bitcoin-rpcpassword",
+            "bitcoin-rpcuser",
+            "dev-bitcoind-poll",
+        ]
+        for opt in opts_to_disable:
+            self.daemon.opts.pop(opt)
 
     # Monkey patch
     def set_feerates(self, feerates, wait_for_effect=True):

--- a/sauron/tests/test_sauron_mempoolspace_signet.py
+++ b/sauron/tests/test_sauron_mempoolspace_signet.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import os
-
 import pyln
 import pytest
 from pyln.testing import utils
@@ -10,25 +9,33 @@ from util import LightningD
 
 pyln.testing.fixtures.network_daemons["signet"] = utils.BitcoinD
 
-
 class LightningNode(utils.LightningNode):
     def __init__(self, *args, **kwargs):
         pyln.testing.utils.TEST_NETWORK = "signet"
         utils.LightningNode.__init__(self, *args, **kwargs)
         lightning_dir = args[1]
-        self.daemon = LightningD(lightning_dir, None, port=self.daemon.port)  # noqa: F405
-        options = {
-            "disable-plugin": "bcli",
+        old_opts = self.daemon.opts
+        self.daemon = LightningD(lightning_dir, None)  # noqa: F405
+        new_opts = {
+            "disable-plugin": ["bcli"],
             "network": "signet",
             "plugin": os.path.join(os.path.dirname(__file__), "../sauron.py"),
             "sauron-api-endpoint": "https://mutinynet.com/api",
         }
-        self.daemon.opts.update(options)
+        self.daemon.opts.update(old_opts)
+        self.daemon.opts.update(new_opts)
+        opts_to_disable = [
+            "bitcoin-datadir",
+            "bitcoin-rpcpassword",
+            "bitcoin-rpcuser",
+            "dev-bitcoind-poll",
+        ]
+        for opt in opts_to_disable:
+            self.daemon.opts.pop(opt)
 
     # Monkey patch
     def set_feerates(self, feerates, wait_for_effect=True):
         return None
-
 
 @pytest.fixture
 def node_cls(monkeypatch):
@@ -36,7 +43,7 @@ def node_cls(monkeypatch):
     yield LightningNode
 
 
-def test_rpc_getchaininfo(node_factory):
+def test_mempoolspace_signet_getchaininfo(node_factory):
     """
     Test getchaininfo
     """
@@ -52,7 +59,7 @@ def test_rpc_getchaininfo(node_factory):
     assert not response["ibd"]
 
 
-def test_rpc_getrawblockbyheight(node_factory):
+def test_mempoolspace_signet_getrawblockbyheight(node_factory):
     """
     Test getrawblockbyheight
     """
@@ -67,7 +74,7 @@ def test_rpc_getrawblockbyheight(node_factory):
     assert response == expected_response
 
 @pytest.mark.skip(reason="testing_theory")
-def test_rpc_sendrawtransaction_invalid(node_factory):
+def test_mempoolspace_signet_sendrawtransaction_invalid(node_factory):
     """
     Test sendrawtransaction
     """
@@ -85,7 +92,7 @@ def test_rpc_sendrawtransaction_invalid(node_factory):
     assert response == expected_response
 
 
-def test_rpc_getutxout(node_factory):
+def test_mempoolspace_signet_getutxout(node_factory):
     """
     Test getutxout
     """
@@ -106,7 +113,7 @@ def test_rpc_getutxout(node_factory):
     assert response == expected_response
 
 
-def test_rpc_estimatefees(node_factory):
+def test_mempoolspace_signet_estimatefees(node_factory):
     """
     Test estimatefees
     """

--- a/sauron/tests/util.py
+++ b/sauron/tests/util.py
@@ -4,18 +4,6 @@ from pyln.testing import utils
 
 
 class LightningD(utils.LightningD):
-    def __init__(self, lightning_dir, *args, **kwargs):
-        super().__init__(lightning_dir, *args, **kwargs)
-
-        opts_to_disable = [
-            "bitcoin-datadir",
-            "bitcoin-rpcpassword",
-            "bitcoin-rpcuser",
-            "dev-bitcoind-poll",
-        ]
-        for opt in opts_to_disable:
-            self.opts.pop(opt)
-
     # Monkey patch
     def start(self, stdin=None, wait_for_initialized=True, stderr_redir=False):
         utils.TailableProc.start(


### PR DESCRIPTION
cln-grpc was dying and taking the rest of lightningd with it (because it's important) because it was trying to listen on port 9736 in multiple tests simlutaneously. this PR allows the sauron tests to take advantage of the new plyn-testing feature that assigns the grpc plugin a random unused port by default. sauron's tests were previously overriding these values in its override fixtures, and this PR corrects that. there is still some brittle- ness around the `TEST_NETWORK` global variable, but setting it in the override `LightningNode` fixture at the top of each test, immediately before the call to init the superclass, appears to make the tests pass, so we'll leave it like this for now.

we also remove the pin to `pyln-client` 24.05, as this requirement no longer seems necessary.

this fixes https://github.com/lightningd/plugins/issues/618

