### PR TITLE
prometheus: Add uv support with inline deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,7 @@ jobs:
         cd lightning
         pip3 install --user -U \
           pip \
+          uv \
           poetry \
           poetry-plugin-export \
           wheel \

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -16,3 +16,46 @@ Exposed variables include:
    HTLCs are currently attached to the channel
  - `funds`: satoshis in on-chain outputs, satoshis allocated to channels and
    total sum (may be inaccurate during channel resolution).
+
+## Installation
+### Using uv (recommended)
+* Install `uv` and make the plugin executable
+```
+pip install --upgrade pip uv
+chmod a+x prometheus.py
+```
+Then you can add _just that file_ to your Core Lightning plugins directory. The plugin should start automatically and its dependencies will be installed on-the-fly when the node comes up.
+
+### Using poetry (legacy)
+If you don't want to use `uv`, you can still use `poetry`. You need to update the shebang line to point the OS at the correct interpreter (`python3`) though:
+```
+sed -i 's#-S uv run --script#python3#' prometheus.py
+```
+
+Then install `poetry` and build the package:
+```
+pip install --upgrade pip poetry
+poetry install --only main
+```
+
+This is an example snippet for installing the plugin's dependencies and cleaning up afterwards:
+```
+PLUGIN_PATH=/opt/plugins
+RAW_GH_PLUGINS=https://raw.githubusercontent.com/lightningd/plugins/master
+mkdir -p ${PLUGIN_PATH}
+
+pip3 install --break-system-packages --upgrade pip wheel poetry
+
+# Add custom plugins (prometheus)
+## This replaces the shebang line that by default uses uv for package management
+(cd $PLUGIN_PATH; wget -q $RAW_GH_PLUGINS/prometheus/README.md \
+  && wget -q $RAW_GH_PLUGINS/prometheus/pyproject.toml \
+  && wget -q $RAW_GH_PLUGINS/prometheus/poetry.lock \
+  && wget -q $RAW_GH_PLUGINS/prometheus/prometheus.py \
+  && sed -i 's#-S uv run --script#python3#' prometheus.py \
+  && poetry config virtualenvs.create false \
+  && PIP_BREAK_SYSTEM_PACKAGES=1 poetry install --only main \
+  && rm -f README.md pyproject.toml poetry.lock)
+
+chmod a+x $PLUGIN_PATH/*
+```

--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -1,4 +1,13 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "prometheus-client>=0.20.0",
+#   "pyln-client>=24.5"
+# ]
+# ///
+
 from pyln.client import Plugin
 from prometheus_client import start_http_server, CollectorRegistry
 from prometheus_client.core import InfoMetricFamily, GaugeMetricFamily


### PR DESCRIPTION
This introduces `uv`, which allows for simpler and more automatic dependency management. Solely having `uv` installed in the environment allows the plugin to work as expected, while its deps are installed at runtime.

The `shebang` at the top of the `prometheus.py` strictly enforces `uv`, so I've left a note in the README on how to revert to `poetry`.