### PR TITLE
CI: update main and add uv support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
         bitcoind-version: ["28.1"]
         cln-version: ["24.11", "25.05", "25.02"]
         experimental: [1]
@@ -71,6 +71,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+
     - name: Extract exact python and os version
       id: exact_versions
       run: |
@@ -108,7 +111,7 @@ jobs:
 
     - name: Save bitcoind cache
       uses: actions/cache/save@v4
-      if: ${{ steps.cache-bitcoind.outputs.cache-hit != 'true' && github.event_name == 'push' }}
+      if: ${{ always() && (github.event_name == 'push' || steps.set_plugin_dirs.outputs.run_ci == 'true') && steps.cache-bitcoind.outputs.cache-hit != 'true' }}
       with:
           path: /usr/local/bin/bitcoin*
           key: cache-bitcoind-${{ matrix.bitcoind-version }}-${{ steps.exact_versions.outputs.os_version }}
@@ -121,7 +124,6 @@ jobs:
         path: |
           /usr/local/bin/lightning*
           /usr/local/libexec/c-lightning
-          ./lightning
         key: cache-cln-${{ matrix.cln-version }}-${{ steps.exact_versions.outputs.os_version }}
 
     - name: Download Core Lightning ${{ matrix.cln-version }} & install binaries
@@ -129,68 +131,19 @@ jobs:
       id: cln-install
       run: |
         url=$(curl -s https://api.github.com/repos/ElementsProject/lightning/releases/tags/v${{ matrix.cln-version }} \
-          | jq '.assets[] | select(.name | contains("22.04")) | .browser_download_url' \
+          | jq '.assets[] | select(.name | contains("24.04")) | .browser_download_url' \
           | tr -d '\"')
         wget $url
         sudo tar -xvf ${url##*/} -C /usr/local --strip-components=2
 
-    - name: Checkout Core Lightning ${{ matrix.cln-version }}
-      if: ${{ steps.cache-cln.outputs.cache-hit != 'true' && (github.event_name == 'push' || steps.set_plugin_dirs.outputs.run_ci == 'true') }}
-      uses: actions/checkout@v4
-      with:
-        repository: 'ElementsProject/lightning'
-        path: 'lightning'
-        ref: 'v${{ matrix.cln-version }}'
-        fetch-depth: 0  # Fetch all history for all branches and tags
-        submodules: 'recursive'
-
     - name: Save CLN cache
       uses: actions/cache/save@v4
-      if: ${{ steps.cache-cln.outputs.cache-hit != 'true' && github.event_name == 'push' }}
+      if: ${{ always() && (github.event_name == 'push' || steps.set_plugin_dirs.outputs.run_ci == 'true') && steps.cache-cln.outputs.cache-hit != 'true' }}
       with:
           path: |
             /usr/local/bin/lightning*
             /usr/local/libexec/c-lightning
-            ./lightning
           key: cache-cln-${{ matrix.cln-version }}-${{ steps.exact_versions.outputs.os_version }}
-
-    - name: Restore python dependencies cache
-      id: cache-python-deps
-      if: ${{ github.event_name == 'push' || steps.set_plugin_dirs.outputs.run_ci == 'true' }}
-      uses: actions/cache@v4
-      with:
-        path: ~/.local/lib/python${{ matrix.python-version }}/site-packages
-        key: cache-python-deps-${{ steps.exact_versions.outputs.python_version }}-${{ matrix.cln-version }}-${{ steps.exact_versions.outputs.os_version }}
-
-    - name: Install Core Lightning Python package dependencies
-      if: ${{ steps.cache-python-deps.outputs.cache-hit != 'true' && (github.event_name == 'push' || steps.set_plugin_dirs.outputs.run_ci == 'true') }}
-      run: |
-        cd lightning
-        pip3 install --user -U \
-          pip \
-          uv \
-          poetry \
-          poetry-plugin-export \
-          wheel \
-          blinker \
-          pytest-custom-exit-code==0.3.0 \
-          pytest-json-report
-
-        poetry install --no-root
-        poetry update
-        poetry export --without-hashes -f requirements.txt --output requirements.txt
-        pip install --user -U -r requirements.txt
-        pip install --user contrib/pyln-client contrib/pyln-testing flaky
-
-        pip3 install --upgrade pip
-        pip3 install --user -U virtualenv pip > /dev/null
-
-    - name: Save python dependencies cache
-      uses: actions/cache/save@v4
-      if: ${{ steps.cache-python-deps.outputs.cache-hit != 'true' && github.event_name == 'push' }}
-      with:
-          path: ~/.local/lib/python${{ matrix.python-version }}/site-packages
-          key: cache-python-deps-${{ steps.exact_versions.outputs.python_version }}-${{ matrix.cln-version }}-${{ steps.exact_versions.outputs.os_version }}
 
     - name: Run pytest tests
       id: pytest_tests
@@ -244,10 +197,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Complete
         run: |
-          python_versions='3.9 3.12'
+          python_versions='3.9 3.13'
           echo "Updating badges data for ${{ matrix.cln-version }} workflow..."
           python3 .ci/update_badges.py ${{ matrix.cln-version }} $(echo "$python_versions")
           echo "CI completed."


### PR DESCRIPTION
- Support uv projects, refactored the explicit tmp directory creation to not run for uv projects
- Update python 3.12 to 3.13 in the matrix (torq-plugin needs to update dependencies for 3.13)
- Detect poetry and uv projects by their .lock files to differentiate them (if both are present due to migration prioritize uv)
- Don't check out lightning repo and pull the published pyln-* packages instead with the matching version to CLN
- Save cache more often, they get deleted after a week anyways and it speeds up PR runs