### PR TITLE
prometheus: Separate `listpeers` from `listpeerchannels` metrics

### DIFF
--- a/prometheus/prometheus.py
+++ b/prometheus/prometheus.py
@@ -81,13 +81,11 @@ class FundsCollector(BaseLnCollector):
         )
 
 
-class PeerCollector(BaseLnCollector):
+class PeerChannelsCollector(BaseLnCollector):
     def collect(self):
-        peers = self.rpc.listpeers()['peers']
-
         connected = GaugeMetricFamily(
-            'lightning_peer_connected',
-            'Is the peer currently connected?',
+            'lightning_peer_channel_connected',
+            'Is the channel peer currently connected?',
             labels=['id'],
         )
         count = GaugeMetricFamily(
@@ -234,7 +232,7 @@ def init(options, configuration, plugin):
     start_http_server(addr=ip, port=port, registry=registry)
     registry.register(NodeCollector(plugin.rpc, registry))
     registry.register(FundsCollector(plugin.rpc, registry))
-    registry.register(PeerCollector(plugin.rpc, registry))
+    registry.register(PeerChannelsCollector(plugin.rpc, registry))
     registry.register(ChannelsCollector(plugin.rpc, registry))
 
 


### PR DESCRIPTION
When experimenting with the metrics, it was very confusing to discover that `lightning_peers_connected` did not refer to the number of connected peers, but rather to the number of peers with channels.

A search through the commit log turned up https://github.com/lightningd/plugins/commit/ce078bb74e10b5dea779fcd9fbe77e1d3e72db7a#diff-cfc589c146eeee8db6b2db1d8dc6e851722e6ea18a2d7d05ebc49b2851012de1R71-L91 which was supposed to be related to `msat` denominations, but seems to have overridden the `listpeers` metrics with `listpeerchannels` data.

This PR does the following:
- Refactors the existing `PeerCollector` to `PeerChannelsCollector`
- Implements a new `PeerCollector` to track raw peers and their connections, regardless of whether they have a channel, introducing a `lightning_peers` metric to track a count of each peer.
- Quietly subverts the `lightning_peer_connected` with actual peer data instead of peer-channel data.
- Renames the prior `lightning_peer_connected` metric data to a new, more clear, `lightning_peer_channel_connected` metric.

Of course, this change could cause unexpected data for users already tracking the `lightning_peer_connected` metric, but IMO the clarification is worth it.