### PR TITLE
CI: add missing dependencies for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,13 @@ jobs:
           protobuf-compiler \
           python3 \
           python3-pip \
-          zlib1g-dev
+          zlib1g-dev \
+          jq \
+          autoconf \
+          automake \
+          libtool \
+          libffi-dev \
+          lowdown
 
         cd lightning
         pip3 install --user -U \


### PR DESCRIPTION
Nightly build is currently broken since it's missing the lowdown dependency. I added lowdown and some others from the install docs to fix this.