### PR TITLE
historian: require python >=3.9.2 for pyln compat

### DIFF
--- a/historian/pyproject.toml
+++ b/historian/pyproject.toml
@@ -3,9 +3,9 @@ name = "historian"
 version = "0.1.0"
 description = "A plugin to store historical Lightning Network gossip in a database."
 readme = "README.md"
-authors = [{name = "Christian Decker", email = "<decker@blockstream.io>"}]
+authors = [{ name = "Christian Decker", email = "<decker@blockstream.io>" }]
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.9.2"
 dependencies = [
     "inotify>=0.2.12",
     "pika>=1.3.2",
@@ -25,7 +25,7 @@ dev = [
 [tool.poetry]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.9.2"
 pyln-client = ">=24.2"
 sqlalchemy = "^2.0.40"
 python-dotenv = "^1.1.0"

--- a/historian/uv.lock
+++ b/historian/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.9"
+revision = 3
+requires-python = ">=3.9.2"
 resolution-markers = [
     "python_full_version >= '3.10'",
     "python_full_version < '3.10'",


### PR DESCRIPTION
otherwise we can't run with pyln-* versions v25.12 or later