### PR TITLE
rebalance: handle channels without short_channel_id

### DIFF
--- a/rebalance/rebalance.py
+++ b/rebalance/rebalance.py
@@ -220,7 +220,7 @@ def amounts_from_scid(scid):
 def peer_from_scid(short_channel_id, my_node_id, payload):
     channels = plugin.rpc.listpeerchannels().get("channels")
     for ch in channels:
-        if ch["short_channel_id"] == short_channel_id:
+        if ch.get("short_channel_id") == short_channel_id:
             return ch["peer_id"]
     raise RpcError(
         "rebalance",


### PR DESCRIPTION
The rebalance plugin can crash in peer_from_scid when listpeerchannels returns entries without a short_channel_id, such as channels that are not yet announced/locked in.

This changes the lookup to use ch.get("short_channel_id") before comparing, matching the defensive pattern already used elsewhere in the plugin.

Observed against Core Lightning v26.06 while running an explicit rebalance; the RPC failed with KeyError: 'short_channel_id'.

Validation:\n- python3 -m py_compile rebalance/rebalance.py rebalance/test_rebalance.py
- Applied equivalent one-line fix on a running node and confirmed explicit rebalance commands complete successfully.